### PR TITLE
Exception Primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-precise-3.6
+            - llvm-toolchain-trusty-3.6
           packages:
             - *BASE_PACKAGES
             - llvm-3.6-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     - env:
         - LLVM_VERSION="3.7"
       <<: *BASE
@@ -54,12 +54,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-precise-3.7
+            - llvm-toolchain-trusty-3.7
           packages:
             - *BASE_PACKAGES
             - llvm-3.7-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     - env:
         - LLVM_VERSION="3.8"
       <<: *BASE
@@ -67,12 +67,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-precise-3.8
+            - llvm-toolchain-trusty-3.8
           packages:
             - *BASE_PACKAGES
             - llvm-3.8-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     # 3.9 seems to have a linking issue :/
     # - env:
     #     - LLVM_VERSION="3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,9 +202,9 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            # - llvm-toolchain-trusty-3.6
-            # - llvm-toolchain-trusty-3.7
-            # - llvm-toolchain-trusty-3.8
+            # - llvm-toolchain-precise-3.6
+            # - llvm-toolchain-precise-3.7
+            # - llvm-toolchain-precise-3.8
             # - llvm-toolchain-trusty-3.9
             # - llvm-toolchain-trusty-4.0
             # - llvm-toolchain-trusty-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ matrix:
         - export PATH=/usr/lib/llvm-8/bin/:$HOME/.local/bin:$PATH
         - export LLVM_PATH=/usr/share/llvm-8/cmake/
       script:
-        - cargo doc --no-default-features --features "target-all,llvm8-0" --color=always
+        - cargo doc --no-default-features --features "target-all,llvm10-0" --color=always
         - echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > target/doc/index.html
       rust: nightly
       name: "GitHub IO Documentation Deployment"
@@ -206,7 +206,9 @@ matrix:
             # - llvm-toolchain-trusty-5.0
             # - llvm-toolchain-trusty-6.0
             # - llvm-toolchain-trusty-7
-            - llvm-toolchain-trusty-8
+            # - llvm-toolchain-trusty-8
+            # - llvm-toolchain-trusty-9
+            - llvm-toolchain-trusty-10
           packages:
             - *BASE_PACKAGES
             # - llvm-3.6-dev
@@ -217,7 +219,10 @@ matrix:
             # - llvm-5.0-dev
             # - llvm-6.0-dev
             # - llvm-7-dev
-            - llvm-8-dev
+            # - llvm-8-dev
+            # - llvm-9-dev
+            - llvm-10-dev
+      dist: bionic
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,8 +187,8 @@ matrix:
         on:
           branch: master
       before_install:
-        - export PATH=/usr/lib/llvm-8/bin/:$HOME/.local/bin:$PATH
-        - export LLVM_PATH=/usr/share/llvm-8/cmake/
+        - export PATH=/usr/lib/llvm-10/bin/:$HOME/.local/bin:$PATH
+        - export LLVM_PATH=/usr/share/llvm-10/cmake/
       script:
         - cargo doc --no-default-features --features "target-all,llvm10-0" --color=always
         - echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > target/doc/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,8 @@ matrix:
           sources:
             - *BASE_SOURCES
             - llvm-toolchain-bionic-9
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *BASE_PACKAGES
             - llvm-9-dev
@@ -173,6 +175,8 @@ matrix:
           sources:
             - *BASE_SOURCES
             - llvm-toolchain-bionic-10
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *BASE_PACKAGES
             - llvm-10-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-trusty-10
+            - llvm-toolchain-bionic-10
           packages:
             - *BASE_PACKAGES
             - llvm-10-dev
@@ -207,8 +207,8 @@ matrix:
             # - llvm-toolchain-trusty-6.0
             # - llvm-toolchain-trusty-7
             # - llvm-toolchain-trusty-8
-            # - llvm-toolchain-trusty-9
-            - llvm-toolchain-trusty-10
+            # - llvm-toolchain-bionic-9
+            - llvm-toolchain-bionic-10
           packages:
             - *BASE_PACKAGES
             # - llvm-3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.6-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     - env:
         - LLVM_VERSION="3.7"
       <<: *BASE
@@ -59,7 +59,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.7-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     - env:
         - LLVM_VERSION="3.8"
       <<: *BASE
@@ -72,7 +72,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.8-dev
       rust: nightly-2019-07-25
-      dist: precise
+      dist: trusty
     # 3.9 seems to have a linking issue :/
     # - env:
     #     - LLVM_VERSION="3.9"
@@ -202,9 +202,9 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            # - llvm-toolchain-precise-3.6
-            # - llvm-toolchain-precise-3.7
-            # - llvm-toolchain-precise-3.8
+            # - llvm-toolchain-trusty-3.6
+            # - llvm-toolchain-trusty-3.7
+            # - llvm-toolchain-trusty-3.8
             # - llvm-toolchain-trusty-3.9
             # - llvm-toolchain-trusty-4.0
             # - llvm-toolchain-trusty-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-trusty-3.6
+            - llvm-toolchain-precise-3.6
           packages:
             - *BASE_PACKAGES
             - llvm-3.6-dev
       rust: nightly-2019-07-25
-      dist: trusty
+      dist: precise
     - env:
         - LLVM_VERSION="3.7"
       <<: *BASE
@@ -54,12 +54,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-trusty-3.7
+            - llvm-toolchain-precise-3.7
           packages:
             - *BASE_PACKAGES
             - llvm-3.7-dev
       rust: nightly-2019-07-25
-      dist: trusty
+      dist: precise
     - env:
         - LLVM_VERSION="3.8"
       <<: *BASE
@@ -67,12 +67,12 @@ matrix:
         apt:
           sources:
             - *BASE_SOURCES
-            - llvm-toolchain-trusty-3.8
+            - llvm-toolchain-precise-3.8
           packages:
             - *BASE_PACKAGES
             - llvm-3.8-dev
       rust: nightly-2019-07-25
-      dist: trusty
+      dist: precise
     # 3.9 seems to have a linking issue :/
     # - env:
     #     - LLVM_VERSION="3.9"
@@ -213,6 +213,8 @@ matrix:
             # - llvm-toolchain-trusty-8
             # - llvm-toolchain-bionic-9
             - llvm-toolchain-bionic-10
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *BASE_PACKAGES
             # - llvm-3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 
-dist: trusty
 sudo: required
 cache:
   directories:
@@ -47,6 +46,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.6-dev
       rust: nightly-2019-07-25
+      dist: precise
     - env:
         - LLVM_VERSION="3.7"
       <<: *BASE
@@ -59,6 +59,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.7-dev
       rust: nightly-2019-07-25
+      dist: precise
     - env:
         - LLVM_VERSION="3.8"
       <<: *BASE
@@ -71,6 +72,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-3.8-dev
       rust: nightly-2019-07-25
+      dist: precise
     # 3.9 seems to have a linking issue :/
     # - env:
     #     - LLVM_VERSION="3.9"
@@ -83,6 +85,8 @@ matrix:
     #       packages:
     #         - *BASE_PACKAGES
     #         - llvm-3.9-dev
+    #       rust: nightly-2019-07-25
+    #       dist: trusty
     - env:
         - LLVM_VERSION="4.0"
       <<: *BASE
@@ -95,6 +99,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-4.0-dev
       rust: nightly-2019-07-25
+      dist: trusty
     - env:
         - LLVM_VERSION="5.0"
       <<: *BASE
@@ -107,6 +112,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-5.0-dev
       rust: nightly-2019-07-25
+      dist: trusty
     - env:
         - LLVM_VERSION="6.0"
       <<: *BASE
@@ -119,6 +125,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-6.0-dev
       rust: nightly-2019-07-25
+      dist: trusty
     - env:
         - LLVM_VERSION="7.0"
       <<: *BASE
@@ -131,6 +138,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-7-dev
       rust: nightly-2019-07-25
+      dist: trusty
     - env:
         - LLVM_VERSION="8.0"
       <<: *BASE
@@ -143,6 +151,33 @@ matrix:
             - *BASE_PACKAGES
             - llvm-8-dev
       rust: nightly-2019-07-25
+      dist: trusty
+    - env:
+        - LLVM_VERSION="9.0"
+      <<: *BASE
+      addons:
+        apt:
+          sources:
+            - *BASE_SOURCES
+            - llvm-toolchain-bionic-9
+          packages:
+            - *BASE_PACKAGES
+            - llvm-9-dev
+      rust: nightly-2019-07-25
+      dist: bionic
+    - env:
+        - LLVM_VERSION="10.0"
+      <<: *BASE
+      addons:
+        apt:
+          sources:
+            - *BASE_SOURCES
+            - llvm-toolchain-trusty-10
+          packages:
+            - *BASE_PACKAGES
+            - llvm-10-dev
+      rust: nightly-2019-07-25
+      dist: bionic
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages
         skip-cleanup: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 edition = "2018"
 
 [features]
-default = ["target-all"]
+default = ["target-all", "llvm10-0"]
 # Please update internal_macros::FEATURE_VERSIONS when adding a new LLVM version
 llvm3-6 = []
 llvm3-7 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ experimental = ["static-alloc"]
 either = "1.5"
 inkwell_internals = { path = "./internal_macros", version = "0.1.0" }
 libc = "0.2"
-llvm-sys = "100.0"
+llvm-sys = "100.0.1"
 once_cell = "1.2"
 parking_lot = "0.10"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ llvm5-0 = []
 llvm6-0 = []
 llvm7-0 = []
 llvm8-0 = []
+llvm9-0 = []
+llvm10-0 = []
 # Don't link aganist LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details.
 no-llvm-linking = ["llvm-sys/no-llvm-linking"]
@@ -63,7 +65,7 @@ experimental = ["static-alloc"]
 either = "1.5"
 inkwell_internals = { path = "./internal_macros", version = "0.1.0" }
 libc = "0.2"
-llvm-sys = "80.1"
+llvm-sys = "100.0"
 once_cell = "1.2"
 parking_lot = "0.10"
 regex = "1"

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -19,8 +19,8 @@ use syn::spanned::Spanned;
 use syn::{Token, LitFloat, Ident, Item, Field, Variant, Attribute};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 9] =
-    ["llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0"];
+const FEATURE_VERSIONS: [&str; 11] =
+    ["llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0"];
 
 /// Gets the index of the feature version that represents `latest`
 fn get_latest_feature_index(features: &[&str]) -> usize {

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -477,8 +477,12 @@ impl<'ctx> BasicBlock<'ctx> {
     pub fn replace_all_uses_with(&self, other: &BasicBlock<'ctx>) {
         let value = unsafe { LLVMBasicBlockAsValue(self.basic_block) };
         let other = unsafe { LLVMBasicBlockAsValue(other.basic_block) };
-        unsafe {
-            LLVMReplaceAllUsesWith(value, other);
+
+        // LLVM may infinite-loop when they aren't distinct, which is UB in C++.
+        if value != other {
+            unsafe {
+                LLVMReplaceAllUsesWith(value, other);
+            }
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -357,13 +357,13 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
     #[llvm_versions(8.0..=latest)]
-    pub fn build_memcpy<T: IntMathValue<'ctx>>(
+    pub fn build_memcpy(
         &self,
         dest: PointerValue<'ctx>,
         dest_align_bytes: u32,
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
-        size: T,
+        size: IntValue<'ctx>,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         let value = unsafe {
             LLVMBuildMemCpy(
@@ -385,13 +385,13 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
     #[llvm_versions(8.0..=latest)]
-    pub fn build_memmove<T: IntMathValue<'ctx>>(
+    pub fn build_memmove(
         &self,
         dest: PointerValue<'ctx>,
         dest_align_bytes: u32,
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
-        size: T,
+        size: IntValue<'ctx>,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         let value = unsafe {
             LLVMBuildMemMove(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination, LLVMAddClause, LLVMBuildInvoke, LLVMBuildLandingPad};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
@@ -168,6 +168,98 @@ impl<'ctx> Builder<'ctx> {
         };
 
         CallSiteValue::new(value)
+    }
+
+    pub fn build_invoke<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        then_block: BasicBlock<'ctx>,
+        catch_block: BasicBlock<'ctx>,
+        name: &str,
+    ) -> CallSiteValue<'ctx>
+    where
+        F: Into<FunctionOrPointerValue<'ctx>>,
+    {
+        let fn_val_ref = match function.into() {
+            Left(val) => val.as_value_ref(),
+            Right(val) => {
+                // If using a pointer value, we must validate it's a valid function ptr
+                let value_ref = val.as_value_ref();
+                let ty_kind = unsafe { LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(value_ref))) };
+                let is_a_fn_ptr = match ty_kind {
+                    LLVMTypeKind::LLVMFunctionTypeKind => true,
+                    _ => false,
+                };
+
+                // REVIEW: We should probably turn this into a Result?
+                assert!(
+                    is_a_fn_ptr,
+                    "build_call called with a pointer which is not a function pointer"
+                );
+
+                value_ref
+            }
+        };
+
+        // LLVM gets upset when void return calls are named because they don't return anything
+        let name = unsafe {
+            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
+                fn_val_ref,
+            )))) {
+                LLVMTypeKind::LLVMVoidTypeKind => "",
+                _ => name,
+            }
+        };
+
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let value = unsafe {
+            LLVMBuildInvoke(
+                self.builder,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                then_block.basic_block,
+                catch_block.basic_block,
+                c_string.as_ptr(),
+            )
+        };
+
+        CallSiteValue::new(value)
+    }
+
+
+    pub fn build_catch_all_landing_pad(
+        &self,
+        ty: &dyn BasicType<'ctx>,
+        value: &dyn BasicValue<'ctx>,
+        ptr_ty: PointerType<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+        let num_clauses = 1 as u32;
+
+        let value = unsafe {
+            LLVMBuildLandingPad(
+                self.builder,
+                ty.as_type_ref(),
+                value.as_value_ref(),
+                num_clauses,
+                c_string.as_ptr(),
+            )
+        };
+
+        // we will add one clause, a null pointer of the specified type
+        // NOTE: the ptr type does not actually matter, but we do need a
+        // pointer type to generate the null pointer
+        let null = ptr_ty.const_zero();
+
+        unsafe {
+            LLVMAddClause(value, null.as_value_ref());
+        };
+
+        BasicValueEnum::new(value)
     }
 
     // REVIEW: Doesn't GEP work on array too?

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
@@ -345,6 +345,60 @@ impl<'ctx> Builder<'ctx> {
         };
 
         PointerValue::new(value)
+    }
+
+    /// Alignment arguments are specified in bytes, and should always be a power of 2.
+    ///
+    /// The final argument should be a pointer-sized integer.
+    ///
+    /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    pub fn build_memcpy<T: IntMathValue<'ctx>>(
+        &self,
+        dest: PointerValue<'ctx>,
+        dest_align_bytes: u32,
+        src: PointerValue<'ctx>,
+        src_align_bytes: u32,
+        size: T,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
+        let value = unsafe {
+            LLVMBuildMemCpy(
+                self.builder,
+                dest.as_value_ref(),
+                dest_align_bytes,
+                src.as_value_ref(),
+                src_align_bytes,
+                size.as_value_ref(),
+            )
+        };
+
+        Ok(PointerValue::new(value))
+    }
+
+    /// Alignment arguments are specified in bytes, and should always be a power of 2.
+    ///
+    /// The final argument should be a pointer-sized integer.
+    ///
+    /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    pub fn build_memmove<T: IntMathValue<'ctx>>(
+        &self,
+        dest: PointerValue<'ctx>,
+        dest_align_bytes: u32,
+        src: PointerValue<'ctx>,
+        src_align_bytes: u32,
+        size: T,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
+        let value = unsafe {
+            LLVMBuildMemMove(
+                self.builder,
+                dest.as_value_ref(),
+                dest_align_bytes,
+                src.as_value_ref(),
+                src_align_bytes,
+                size.as_value_ref(),
+            )
+        };
+
+        Ok(PointerValue::new(value))
     }
 
     // TODOC: Heap allocation

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,27 +4,28 @@ use either::{Either, Left, Right};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 use llvm_sys::core::{
-    LLVMAddCase, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
-    LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca,
-    LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall,
-    LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
+    LLVMAddCase, LLVMAddClause, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd,
+    LLVMBuildAddrSpaceCast, LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd,
+    LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr,
+    LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
     LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
     LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
     LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP,
     LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP,
     LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
-    LLVMBuildIntToPtr, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr, LLVMBuildLoad,
-    LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul, LLVMBuildNSWNeg,
-    LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul, LLVMBuildNUWNeg, LLVMBuildNUWSub,
-    LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildPtrDiff,
-    LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
-    LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl,
-    LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch,
-    LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
-    LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMBuildZExtOrBitCast,
-    LLVMClearInsertionPosition, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock,
-    LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName,
-    LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
+    LLVMBuildIntToPtr, LLVMBuildInvoke, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr,
+    LLVMBuildLandingPad, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd,
+    LLVMBuildNSWMul, LLVMBuildNSWNeg, LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul,
+    LLVMBuildNUWNeg, LLVMBuildNUWSub, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi,
+    LLVMBuildPointerCast, LLVMBuildPtrDiff, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
+    LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem,
+    LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP,
+    LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv,
+    LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor,
+    LLVMBuildZExt, LLVMBuildZExtOrBitCast, LLVMClearInsertionPosition, LLVMDisposeBuilder,
+    LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind,
+    LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName, LLVMPositionBuilder,
+    LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
 };
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
@@ -96,6 +97,38 @@ impl<'ctx> Builder<'ctx> {
         };
 
         InstructionValue::new(value)
+    }
+
+    pub fn build_catch_all_landing_pad(
+        &self,
+        ty: &dyn BasicType<'ctx>,
+        value: &dyn BasicValue<'ctx>,
+        ptr_ty: PointerType<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+        let num_clauses = 1 as u32;
+
+        let value = unsafe {
+            LLVMBuildLandingPad(
+                self.builder,
+                ty.as_type_ref(),
+                value.as_value_ref(),
+                num_clauses,
+                c_string.as_ptr(),
+            )
+        };
+
+        // we will add one clause, a null pointer of the specified type
+        // NOTE: the ptr type does not actually matter, but we do need a
+        // pointer type to generate the null pointer
+        let null = ptr_ty.const_zero();
+
+        unsafe {
+            LLVMAddClause(value, null.as_value_ref());
+        };
+
+        BasicValueEnum::new(value)
     }
 
     /// Builds a function return instruction for a return type which is an aggregate type (ie structs and arrays).
@@ -208,6 +241,65 @@ impl<'ctx> Builder<'ctx> {
                 fn_val_ref,
                 args.as_mut_ptr(),
                 args.len() as u32,
+                c_string.as_ptr(),
+            )
+        };
+
+        CallSiteValue::new(value)
+    }
+
+    pub fn build_invoke<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        then_block: BasicBlock<'ctx>,
+        catch_block: BasicBlock<'ctx>,
+        name: &str,
+    ) -> CallSiteValue<'ctx>
+    where
+        F: Into<FunctionOrPointerValue<'ctx>>,
+    {
+        let fn_val_ref = match function.into() {
+            Left(val) => val.as_value_ref(),
+            Right(val) => {
+                // If using a pointer value, we must validate it's a valid function ptr
+                let value_ref = val.as_value_ref();
+                let ty_kind = unsafe { LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(value_ref))) };
+                let is_a_fn_ptr = match ty_kind {
+                    LLVMTypeKind::LLVMFunctionTypeKind => true,
+                    _ => false,
+                };
+
+                // REVIEW: We should probably turn this into a Result?
+                assert!(
+                    is_a_fn_ptr,
+                    "build_call called with a pointer which is not a function pointer"
+                );
+
+                value_ref
+            }
+        };
+
+        // LLVM gets upset when void return calls are named because they don't return anything
+        let name = unsafe {
+            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
+                fn_val_ref,
+            )))) {
+                LLVMTypeKind::LLVMVoidTypeKind => "",
+                _ => name,
+            }
+        };
+
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let value = unsafe {
+            LLVMBuildInvoke(
+                self.builder,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                then_block.basic_block,
+                catch_block.basic_block,
                 c_string.as_ptr(),
             )
         };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,48 +1,20 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
-use llvm_sys::core::{
-    LLVMAddCase, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
-    LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca,
-    LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall,
-    LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
-    LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
-    LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
-    LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP,
-    LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP,
-    LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
-    LLVMBuildIntToPtr, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr, LLVMBuildLoad,
-    LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul, LLVMBuildNSWNeg,
-    LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul, LLVMBuildNUWNeg, LLVMBuildNUWSub,
-    LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildPtrDiff,
-    LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
-    LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl,
-    LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch,
-    LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
-    LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMBuildZExtOrBitCast,
-    LLVMClearInsertionPosition, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock,
-    LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName,
-    LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
-};
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
-use llvm_sys::LLVMTypeKind;
+use llvm_sys::{LLVMTypeKind};
 
+use crate::{AtomicOrdering, AtomicRMWBinOp, IntPredicate, FloatPredicate};
 use crate::basic_block::BasicBlock;
-use crate::types::{
-    AsTypeRef, BasicType, FloatMathType, IntMathType, PointerMathType, PointerType,
-};
+use crate::values::{AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, PointerMathValue, InstructionOpcode, CallSiteValue};
 #[llvm_versions(3.9..=latest)]
 use crate::values::StructValue;
-use crate::values::{
-    AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, CallSiteValue,
-    FloatMathValue, FunctionValue, GlobalValue, InstructionOpcode, InstructionValue, IntMathValue,
-    IntValue, PhiValue, PointerMathValue, PointerValue, VectorValue,
-};
-use crate::{AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
+use crate::types::{AsTypeRef, BasicType, IntMathType, FloatMathType, PointerType, PointerMathType};
 
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -89,10 +61,7 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     pub fn build_return(&self, value: Option<&dyn BasicValue<'ctx>>) -> InstructionValue<'ctx> {
         let value = unsafe {
-            value.map_or_else(
-                || LLVMBuildRetVoid(self.builder),
-                |value| LLVMBuildRet(self.builder, value.as_value_ref()),
-            )
+            value.map_or_else(|| LLVMBuildRetVoid(self.builder), |value| LLVMBuildRet(self.builder, value.as_value_ref()))
         };
 
         InstructionValue::new(value)
@@ -121,13 +90,13 @@ impl<'ctx> Builder<'ctx> {
     /// builder.position_at_end(entry);
     /// builder.build_aggregate_return(&[i32_three.into(), i32_seven.into()]);
     /// ```
-    pub fn build_aggregate_return(
-        &self,
-        values: &[BasicValueEnum<'ctx>],
-    ) -> InstructionValue<'ctx> {
-        let mut args: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        let value =
-            unsafe { LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32) };
+    pub fn build_aggregate_return(&self, values: &[BasicValueEnum<'ctx>]) -> InstructionValue<'ctx> {
+        let mut args: Vec<LLVMValueRef> = values.iter()
+                                                .map(|val| val.as_value_ref())
+                                                .collect();
+        let value = unsafe {
+            LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32)
+        };
 
         InstructionValue::new(value)
     }
@@ -160,12 +129,7 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&ret_val));
     /// ```
-    pub fn build_call<F>(
-        &self,
-        function: F,
-        args: &[BasicValueEnum<'ctx>],
-        name: &str,
-    ) -> CallSiteValue<'ctx>
+    pub fn build_call<F>(&self, function: F, args: &[BasicValueEnum<'ctx>], name: &str) -> CallSiteValue<'ctx>
     where
         F: Into<FunctionOrPointerValue<'ctx>>,
     {
@@ -181,35 +145,26 @@ impl<'ctx> Builder<'ctx> {
                 };
 
                 // REVIEW: We should probably turn this into a Result?
-                assert!(
-                    is_a_fn_ptr,
-                    "build_call called with a pointer which is not a function pointer"
-                );
+                assert!(is_a_fn_ptr, "build_call called with a pointer which is not a function pointer");
 
                 value_ref
-            }
+            },
         };
 
         // LLVM gets upset when void return calls are named because they don't return anything
         let name = unsafe {
-            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
-                fn_val_ref,
-            )))) {
+            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(fn_val_ref)))) {
                 LLVMTypeKind::LLVMVoidTypeKind => "",
                 _ => name,
             }
         };
 
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let mut args: Vec<LLVMValueRef> = args.iter()
+                                              .map(|val| val.as_value_ref())
+                                              .collect();
         let value = unsafe {
-            LLVMBuildCall(
-                self.builder,
-                fn_val_ref,
-                args.as_mut_ptr(),
-                args.len() as u32,
-                c_string.as_ptr(),
-            )
+            LLVMBuildCall(self.builder, fn_val_ref, args.as_mut_ptr(), args.len() as u32, c_string.as_ptr())
         };
 
         CallSiteValue::new(value)
@@ -217,25 +172,13 @@ impl<'ctx> Builder<'ctx> {
 
     // REVIEW: Doesn't GEP work on array too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_gep(
-        &self,
-        ptr: PointerValue<'ctx>,
-        ordered_indexes: &[IntValue<'ctx>],
-        name: &str,
-    ) -> PointerValue<'ctx> {
+    pub unsafe fn build_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
-            .iter()
-            .map(|val| val.as_value_ref())
-            .collect();
-        let value = LLVMBuildGEP(
-            self.builder,
-            ptr.as_value_ref(),
-            index_values.as_mut_ptr(),
-            index_values.len() as u32,
-            c_string.as_ptr(),
-        );
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
+                                                                 .map(|val| val.as_value_ref())
+                                                                 .collect();
+        let value = LLVMBuildGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
 
         PointerValue::new(value)
     }
@@ -243,25 +186,13 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Doesn't GEP work on array too?
     // REVIEW: This could be merge in with build_gep via a in_bounds: bool param
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_in_bounds_gep(
-        &self,
-        ptr: PointerValue<'ctx>,
-        ordered_indexes: &[IntValue<'ctx>],
-        name: &str,
-    ) -> PointerValue<'ctx> {
+    pub unsafe fn build_in_bounds_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
-            .iter()
-            .map(|val| val.as_value_ref())
-            .collect();
-        let value = LLVMBuildInBoundsGEP(
-            self.builder,
-            ptr.as_value_ref(),
-            index_values.as_mut_ptr(),
-            index_values.len() as u32,
-            c_string.as_ptr(),
-        );
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
+                                                                 .map(|val| val.as_value_ref())
+                                                                 .collect();
+        let value = LLVMBuildInBoundsGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
 
         PointerValue::new(value)
     }
@@ -270,12 +201,7 @@ impl<'ctx> Builder<'ctx> {
     // I think it's the latter. This might not be as unsafe as regular GEP. Should check to see if it lets us
     // go OOB. Maybe we could use the PointerValue<StructValue>'s struct info to do bounds checking...
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_struct_gep(
-        &self,
-        ptr: PointerValue<'ctx>,
-        index: u32,
-        name: &str,
-    ) -> PointerValue<'ctx> {
+    pub unsafe fn build_struct_gep(&self, ptr: PointerValue<'ctx>, index: u32, name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = LLVMBuildStructGEP(self.builder, ptr.as_value_ref(), index, c_string.as_ptr());
@@ -308,21 +234,11 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_ptr_diff(i32_ptr_param1, i32_ptr_param2, "diff");
     /// builder.build_return(None);
     /// ```
-    pub fn build_ptr_diff(
-        &self,
-        lhs_ptr: PointerValue<'ctx>,
-        rhs_ptr: PointerValue<'ctx>,
-        name: &str,
-    ) -> IntValue<'ctx> {
+    pub fn build_ptr_diff(&self, lhs_ptr: PointerValue<'ctx>, rhs_ptr: PointerValue<'ctx>, name: &str) -> IntValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPtrDiff(
-                self.builder,
-                lhs_ptr.as_value_ref(),
-                rhs_ptr.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildPtrDiff(self.builder, lhs_ptr.as_value_ref(), rhs_ptr.as_value_ref(), c_string.as_ptr())
         };
 
         IntValue::new(value)
@@ -336,7 +252,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_phi<T: BasicType<'ctx>>(&self, type_: T, name: &str) -> PhiValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr())
+        };
 
         PhiValue::new(value)
     }
@@ -366,13 +284,10 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_store(i32_ptr_param, i32_seven);
     /// builder.build_return(None);
     /// ```
-    pub fn build_store<V: BasicValue<'ctx>>(
-        &self,
-        ptr: PointerValue<'ctx>,
-        value: V,
-    ) -> InstructionValue<'ctx> {
-        let value =
-            unsafe { LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref()) };
+    pub fn build_store<V: BasicValue<'ctx>>(&self, ptr: PointerValue<'ctx>, value: V) -> InstructionValue<'ctx> {
+        let value = unsafe {
+            LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref())
+        };
 
         InstructionValue::new(value)
     }
@@ -405,7 +320,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr())
+        };
 
         BasicValueEnum::new(value)
     }
@@ -414,27 +331,19 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_alloca<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr())
+        };
 
         PointerValue::new(value)
     }
 
     // TODOC: Stack allocation
-    pub fn build_array_alloca<T: BasicType<'ctx>>(
-        &self,
-        ty: T,
-        size: IntValue<'ctx>,
-        name: &str,
-    ) -> PointerValue<'ctx> {
+    pub fn build_array_alloca<T: BasicType<'ctx>>(&self, ty: T, size: IntValue<'ctx>, name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildArrayAlloca(
-                self.builder,
-                ty.as_type_ref(),
-                size.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildArrayAlloca(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
         };
 
         PointerValue::new(value)
@@ -501,11 +410,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     // TODOC: Heap allocation
-    pub fn build_malloc<T: BasicType<'ctx>>(
-        &self,
-        ty: T,
-        name: &str,
-    ) -> Result<PointerValue<'ctx>, &'static str> {
+    pub fn build_malloc<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidMalloc segfaults if ty is unsized
         if !ty.is_sized() {
             return Err("Cannot build malloc call for an unsized type");
@@ -513,7 +418,9 @@ impl<'ctx> Builder<'ctx> {
 
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr())
+        };
 
         Ok(PointerValue::new(value))
     }
@@ -523,7 +430,7 @@ impl<'ctx> Builder<'ctx> {
         &self,
         ty: T,
         size: IntValue<'ctx>,
-        name: &str,
+        name: &str
     ) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidArrayMalloc segfaults if ty is unsized
         if !ty.is_sized() {
@@ -533,12 +440,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildArrayMalloc(
-                self.builder,
-                ty.as_type_ref(),
-                size.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildArrayMalloc(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
         };
 
         Ok(PointerValue::new(value))
@@ -546,7 +448,9 @@ impl<'ctx> Builder<'ctx> {
 
     // SubType: <P>(&self, ptr: PointerValue<P>) -> InstructionValue {
     pub fn build_free(&self, ptr: PointerValue<'ctx>) -> InstructionValue<'ctx> {
-        let val = unsafe { LLVMBuildFree(self.builder, ptr.as_value_ref()) };
+        let val = unsafe {
+            LLVMBuildFree(self.builder, ptr.as_value_ref())
+        };
 
         InstructionValue::new(val)
     }
@@ -554,17 +458,12 @@ impl<'ctx> Builder<'ctx> {
     pub fn insert_instruction(&self, instruction: &InstructionValue<'ctx>, name: Option<&str>) {
         match name {
             Some(name) => {
-                let c_string =
-                    CString::new(name).expect("Conversion to CString failed unexpectedly");
+                let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
                 unsafe {
-                    LLVMInsertIntoBuilderWithName(
-                        self.builder,
-                        instruction.as_value_ref(),
-                        c_string.as_ptr(),
-                    )
+                    LLVMInsertIntoBuilderWithName(self.builder, instruction.as_value_ref(), c_string.as_ptr())
                 }
-            }
+            },
             None => unsafe {
                 LLVMInsertIntoBuilder(self.builder, instruction.as_value_ref());
             },
@@ -572,7 +471,9 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn get_insert_block(&self) -> Option<BasicBlock<'ctx>> {
-        let bb = unsafe { LLVMGetInsertBlock(self.builder) };
+        let bb = unsafe {
+            LLVMGetInsertBlock(self.builder)
+        };
 
         BasicBlock::new(bb)
     }
@@ -584,12 +485,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildUDiv(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildUDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -601,12 +497,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSDiv(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -614,21 +505,11 @@ impl<'ctx> Builder<'ctx> {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(
-        &self,
-        lhs: T,
-        rhs: T,
-        name: &str,
-    ) -> T {
+    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildExactSDiv(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildExactSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -640,16 +521,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildURem(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildURem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
+
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
@@ -657,32 +534,17 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSRem(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSExt(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -698,12 +560,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAddrSpaceCast(
-                self.builder,
-                ptr_val.as_value_ref(),
-                ptr_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildAddrSpaceCast(self.builder, ptr_val.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
         };
 
         PointerValue::new(value)
@@ -744,112 +601,57 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildBitCast(
-                self.builder,
-                val.as_value_ref(),
-                ty.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildBitCast(self.builder, val.as_value_ref(), ty.as_type_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)
     }
 
-    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSExtOrBitCast(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildZExt(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+       let value = unsafe {
+            LLVMBuildZExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildZExtOrBitCast(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+       let value = unsafe {
+            LLVMBuildZExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_truncate<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildTrunc(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+       let value = unsafe {
+            LLVMBuildTrunc(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(
-        &self,
-        int_value: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildTruncOrBitCast(
-                self.builder,
-                int_value.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+       let value = unsafe {
+            LLVMBuildTruncOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -859,12 +661,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFRem(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -880,12 +677,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPToUI(
-                self.builder,
-                float.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFPToUI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -900,12 +692,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPToSI(
-                self.builder,
-                float.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFPToSI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -921,12 +708,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildUIToFP(
-                self.builder,
-                int.as_value_ref(),
-                float_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildUIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
@@ -941,93 +723,48 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSIToFP(
-                self.builder,
-                int.as_value_ref(),
-                float_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(
-        &self,
-        float: T,
-        float_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPTrunc(
-                self.builder,
-                float.as_value_ref(),
-                float_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFPTrunc(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_float_ext<T: FloatMathValue<'ctx>>(
-        &self,
-        float: T,
-        float_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_float_ext<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPExt(
-                self.builder,
-                float.as_value_ref(),
-                float_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFPExt(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
-    pub fn build_float_cast<T: FloatMathValue<'ctx>>(
-        &self,
-        float: T,
-        float_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_float_cast<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPCast(
-                self.builder,
-                float.as_value_ref(),
-                float_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFPCast(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
     }
 
     // SubType: <L, R>(&self, lhs: &IntValue<L>, rhs: &IntType<R>, name: &str) -> IntValue<R> {
-    pub fn build_int_cast<T: IntMathValue<'ctx>>(
-        &self,
-        int: T,
-        int_type: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_int_cast<T: IntMathValue<'ctx>>(&self, int: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildIntCast(
-                self.builder,
-                int.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildIntCast(self.builder, int.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1037,12 +774,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFDiv(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1053,12 +785,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAdd(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1070,12 +797,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWAdd(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNSWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1087,12 +809,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWAdd(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNUWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1103,12 +820,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFAdd(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1119,12 +831,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildXor(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildXor(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1135,12 +842,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAnd(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildAnd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1151,12 +853,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildOr(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildOr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1209,12 +906,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildShl(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildShl(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1284,30 +976,14 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_right_shift<T: IntMathValue<'ctx>>(
-        &self,
-        lhs: T,
-        rhs: T,
-        sign_extend: bool,
-        name: &str,
-    ) -> T {
+    pub fn build_right_shift<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, sign_extend: bool, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             if sign_extend {
-                LLVMBuildAShr(
-                    self.builder,
-                    lhs.as_value_ref(),
-                    rhs.as_value_ref(),
-                    c_string.as_ptr(),
-                )
+                LLVMBuildAShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
             } else {
-                LLVMBuildLShr(
-                    self.builder,
-                    lhs.as_value_ref(),
-                    rhs.as_value_ref(),
-                    c_string.as_ptr(),
-                )
+                LLVMBuildLShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
             }
         };
 
@@ -1319,12 +995,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSub(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1335,12 +1006,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWSub(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNSWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1352,12 +1018,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWSub(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNUWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1368,12 +1029,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFSub(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1384,12 +1040,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildMul(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1401,12 +1052,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWMul(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNSWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1418,12 +1064,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWMul(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildNUWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1434,12 +1075,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFMul(
-                self.builder,
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1455,34 +1091,18 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildCast(
-                self.builder,
-                op.into(),
-                from_value.as_value_ref(),
-                to_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildCast(self.builder, op.into(), from_value.as_value_ref(), to_type.as_type_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)
     }
 
     // SubType: <F, T>(&self, from: &PointerValue<F>, to: &PointerType<T>, name: &str) -> PointerValue<T> {
-    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(
-        &self,
-        from: T,
-        to: T::BaseType,
-        name: &str,
-    ) -> T {
+    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(&self, from: T, to: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPointerCast(
-                self.builder,
-                from.as_value_ref(),
-                to.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildPointerCast(self.builder, from.as_value_ref(), to.as_type_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1492,23 +1112,11 @@ impl<'ctx> Builder<'ctx> {
     // Note: we need a way to get an appropriate return type, since this method's return value
     // is always a bool (or vector of bools), not necessarily the same as the input value
     // See https://github.com/TheDan64/inkwell/pull/47#discussion_r197599297
-    pub fn build_int_compare<T: IntMathValue<'ctx>>(
-        &self,
-        op: IntPredicate,
-        lhs: T,
-        rhs: T,
-        name: &str,
-    ) -> T {
+    pub fn build_int_compare<T: IntMathValue<'ctx>>(&self, op: IntPredicate, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildICmp(
-                self.builder,
-                op.into(),
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildICmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         T::new(value)
@@ -1526,23 +1134,16 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFCmp(
-                self.builder,
-                op.into(),
-                lhs.as_value_ref(),
-                rhs.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildFCmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_unconditional_branch(
-        &self,
-        destination_block: BasicBlock<'ctx>,
-    ) -> InstructionValue<'ctx> {
-        let value = unsafe { LLVMBuildBr(self.builder, destination_block.basic_block) };
+    pub fn build_unconditional_branch(&self, destination_block: BasicBlock<'ctx>) -> InstructionValue<'ctx> {
+        let value = unsafe {
+            LLVMBuildBr(self.builder, destination_block.basic_block)
+        };
 
         InstructionValue::new(value)
     }
@@ -1554,12 +1155,7 @@ impl<'ctx> Builder<'ctx> {
         else_block: BasicBlock<'ctx>,
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildCondBr(
-                self.builder,
-                comparison.as_value_ref(),
-                then_block.basic_block,
-                else_block.basic_block,
-            )
+            LLVMBuildCondBr(self.builder, comparison.as_value_ref(), then_block.basic_block, else_block.basic_block)
         };
 
         InstructionValue::new(value)
@@ -1571,15 +1167,13 @@ impl<'ctx> Builder<'ctx> {
         destinations: &[BasicBlock<'ctx>],
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildIndirectBr(
-                self.builder,
-                address.as_value_ref(),
-                destinations.len() as u32,
-            )
+            LLVMBuildIndirectBr(self.builder, address.as_value_ref(), destinations.len() as u32)
         };
 
         for destination in destinations {
-            unsafe { LLVMAddDestination(value, destination.basic_block) }
+            unsafe {
+                LLVMAddDestination(value, destination.basic_block)
+            }
         }
 
         InstructionValue::new(value)
@@ -1589,7 +1183,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
+        };
 
         T::new(value)
     }
@@ -1599,8 +1195,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nsw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value =
-            unsafe { LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
+        };
 
         T::new(value)
     }
@@ -1609,8 +1206,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nuw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value =
-            unsafe { LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
+        };
 
         T::new(value)
     }
@@ -1619,7 +1217,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_float_neg<T: FloatMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
+        };
 
         T::new(value)
     }
@@ -1628,7 +1228,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_not<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe { LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr())
+        };
 
         T::new(value)
     }
@@ -1637,16 +1239,14 @@ impl<'ctx> Builder<'ctx> {
     // It'd be great if we could get the BB from the instruction behind the scenes
     pub fn position_at(&self, basic_block: BasicBlock<'ctx>, instruction: &InstructionValue<'ctx>) {
         unsafe {
-            LLVMPositionBuilder(
-                self.builder,
-                basic_block.basic_block,
-                instruction.as_value_ref(),
-            )
+            LLVMPositionBuilder(self.builder, basic_block.basic_block, instruction.as_value_ref())
         }
     }
 
     pub fn position_before(&self, instruction: &InstructionValue<'ctx>) {
-        unsafe { LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref()) }
+        unsafe {
+            LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref())
+        }
     }
 
     pub fn position_at_end(&self, basic_block: BasicBlock<'ctx>) {
@@ -1750,13 +1350,7 @@ impl<'ctx> Builder<'ctx> {
     /// assert!(builder.build_insert_value(array, const_int3, 2, "insert").is_some());
     /// assert!(builder.build_insert_value(array, const_int3, 3, "insert").is_none());
     /// ```
-    pub fn build_insert_value<AV, BV>(
-        &self,
-        agg: AV,
-        value: BV,
-        index: u32,
-        name: &str,
-    ) -> Option<AggregateValueEnum<'ctx>>
+    pub fn build_insert_value<AV, BV>(&self, agg: AV, value: BV, index: u32, name: &str) -> Option<AggregateValueEnum<'ctx>>
     where
         AV: AggregateValue<'ctx>,
         BV: BasicValue<'ctx>,
@@ -1773,13 +1367,7 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildInsertValue(
-                self.builder,
-                agg.as_value_ref(),
-                value.as_value_ref(),
-                index,
-                c_string.as_ptr(),
-            )
+            LLVMBuildInsertValue(self.builder, agg.as_value_ref(), value.as_value_ref(), index, c_string.as_ptr())
         };
 
         Some(AggregateValueEnum::new(value))
@@ -1809,21 +1397,11 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&extracted));
     /// ```
-    pub fn build_extract_element(
-        &self,
-        vector: VectorValue<'ctx>,
-        index: IntValue<'ctx>,
-        name: &str,
-    ) -> BasicValueEnum<'ctx> {
+    pub fn build_extract_element(&self, vector: VectorValue<'ctx>, index: IntValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildExtractElement(
-                self.builder,
-                vector.as_value_ref(),
-                index.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildExtractElement(self.builder, vector.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)
@@ -1864,83 +1442,60 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildInsertElement(
-                self.builder,
-                vector.as_value_ref(),
-                element.as_value_ref(),
-                index.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildInsertElement(self.builder, vector.as_value_ref(), element.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
         };
 
         VectorValue::new(value)
     }
 
     pub fn build_unreachable(&self) -> InstructionValue<'ctx> {
-        let val = unsafe { LLVMBuildUnreachable(self.builder) };
+        let val = unsafe {
+            LLVMBuildUnreachable(self.builder)
+        };
 
         InstructionValue::new(val)
     }
 
     // REVIEW: Not sure if this should return InstructionValue or an actual value
     // TODO: Better name for num?
-    pub fn build_fence(
-        &self,
-        atomic_ordering: AtomicOrdering,
-        num: i32,
-        name: &str,
-    ) -> InstructionValue<'ctx> {
+    pub fn build_fence(&self, atomic_ordering: AtomicOrdering, num: i32, name: &str) -> InstructionValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val =
-            unsafe { LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr()) };
+        let val = unsafe {
+            LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr())
+        };
 
         InstructionValue::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_null<T: PointerMathValue<'ctx>>(
-        &self,
-        ptr: T,
-        name: &str,
-    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val = unsafe { LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
+        let val = unsafe {
+            LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
+        };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(
-        &self,
-        ptr: T,
-        name: &str,
-    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val =
-            unsafe { LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
+        let val = unsafe {
+            LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
+        };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <I, P>(&self, int: &IntValue<I>, ptr_type: &PointerType<P>, name) -> PointerValue<P> {
-    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(
-        &self,
-        int: T,
-        ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType,
-        name: &str,
-    ) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
+    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(&self, int: T, ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildIntToPtr(
-                self.builder,
-                int.as_value_ref(),
-                ptr_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildIntToPtr(self.builder, int.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType::new(value)
@@ -1956,63 +1511,40 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPtrToInt(
-                self.builder,
-                ptr.as_value_ref(),
-                int_type.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildPtrToInt(self.builder, ptr.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn clear_insertion_position(&self) {
-        unsafe { LLVMClearInsertionPosition(self.builder) }
+        unsafe {
+            LLVMClearInsertionPosition(self.builder)
+        }
     }
 
     // REVIEW: Returning InstructionValue is the safe move here; but if the value means something
     // (IE the result of the switch) it should probably return BasicValueEnum?
     // SubTypes: I think value and case values must be the same subtype (maybe). Case value might need to be constants
-    pub fn build_switch(
-        &self,
-        value: IntValue<'ctx>,
-        else_block: BasicBlock<'ctx>,
-        cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)],
-    ) -> InstructionValue<'ctx> {
+    pub fn build_switch(&self, value: IntValue<'ctx>, else_block: BasicBlock<'ctx>, cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)]) -> InstructionValue<'ctx> {
         let switch_value = unsafe {
-            LLVMBuildSwitch(
-                self.builder,
-                value.as_value_ref(),
-                else_block.basic_block,
-                cases.len() as u32,
-            )
+            LLVMBuildSwitch(self.builder, value.as_value_ref(), else_block.basic_block, cases.len() as u32)
         };
 
         for &(value, basic_block) in cases {
-            unsafe { LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block) }
+            unsafe {
+                LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block)
+            }
         }
 
         InstructionValue::new(switch_value)
     }
 
     // SubTypes: condition can only be IntValue<bool> or VectorValue<IntValue<Bool>>
-    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(
-        &self,
-        condition: IMV,
-        then: BV,
-        else_: BV,
-        name: &str,
-    ) -> BasicValueEnum<'ctx> {
+    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(&self, condition: IMV, then: BV, else_: BV, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildSelect(
-                self.builder,
-                condition.as_value_ref(),
-                then.as_value_ref(),
-                else_.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildSelect(self.builder, condition.as_value_ref(), then.as_value_ref(), else_.as_value_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)
@@ -2020,14 +1552,9 @@ impl<'ctx> Builder<'ctx> {
 
     // The unsafety of this function should be fixable with subtypes. See GH #32
     pub unsafe fn build_global_string(&self, value: &str, name: &str) -> GlobalValue<'ctx> {
-        let c_string_value =
-            CString::new(value).expect("Conversion to CString failed unexpectedly");
+        let c_string_value = CString::new(value).expect("Conversion to CString failed unexpectedly");
         let c_string_name = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let value = LLVMBuildGlobalString(
-            self.builder,
-            c_string_value.as_ptr(),
-            c_string_name.as_ptr(),
-        );
+        let value = LLVMBuildGlobalString(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr());
 
         GlobalValue::new(value)
     }
@@ -2035,37 +1562,20 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Does this similar fn have the same issue build_global_string does? If so, mark as unsafe
     // and fix with subtypes.
     pub fn build_global_string_ptr(&self, value: &str, name: &str) -> GlobalValue<'ctx> {
-        let c_string_value =
-            CString::new(value).expect("Conversion to CString failed unexpectedly");
+        let c_string_value = CString::new(value).expect("Conversion to CString failed unexpectedly");
         let c_string_name = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildGlobalStringPtr(
-                self.builder,
-                c_string_value.as_ptr(),
-                c_string_name.as_ptr(),
-            )
+            LLVMBuildGlobalStringPtr(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr())
         };
 
         GlobalValue::new(value)
     }
 
     // REVIEW: Do we need to constrain types here? subtypes?
-    pub fn build_shuffle_vector(
-        &self,
-        left: VectorValue<'ctx>,
-        right: VectorValue<'ctx>,
-        mask: VectorValue<'ctx>,
-        name: &str,
-    ) -> VectorValue<'ctx> {
+    pub fn build_shuffle_vector(&self, left: VectorValue<'ctx>, right: VectorValue<'ctx>, mask: VectorValue<'ctx>, name: &str) -> VectorValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildShuffleVector(
-                self.builder,
-                left.as_value_ref(),
-                right.as_value_ref(),
-                mask.as_value_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildShuffleVector(self.builder, left.as_value_ref(), right.as_value_ref(), mask.as_value_ref(), c_string.as_ptr())
         };
 
         VectorValue::new(value)
@@ -2074,21 +1584,11 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Is return type correct?
     // SubTypes: I think this should be type: BT -> BT::Value
     // https://llvm.org/docs/LangRef.html#i-va-arg
-    pub fn build_va_arg<BT: BasicType<'ctx>>(
-        &self,
-        list: PointerValue<'ctx>,
-        type_: BT,
-        name: &str,
-    ) -> BasicValueEnum<'ctx> {
+    pub fn build_va_arg<BT: BasicType<'ctx>>(&self, list: PointerValue<'ctx>, type_: BT, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildVAArg(
-                self.builder,
-                list.as_value_ref(),
-                type_.as_type_ref(),
-                c_string.as_ptr(),
-            )
+            LLVMBuildVAArg(self.builder, list.as_value_ref(), type_.as_type_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)
@@ -2127,9 +1627,8 @@ impl<'ctx> Builder<'ctx> {
         // TODO: add support for fadd, fsub and xchg on floating point types in LLVM 9+.
 
         // "The type of ‘<value>’ must be an integer type whose bit width is a power of two greater than or equal to eight and less than or equal to a target-specific size limit. The type of the ‘<pointer>’ operand must be a pointer to that type." -- https://releases.llvm.org/3.6.2/docs/LangRef.html#atomicrmw-instruction
-        if value.get_type().get_bit_width() < 8
-            || !value.get_type().get_bit_width().is_power_of_two()
-        {
+        if value.get_type().get_bit_width() < 8 ||
+           !value.get_type().get_bit_width().is_power_of_two() {
             return Err("The bitwidth of value must be a power of 2 and greater than 8.");
         }
         if ptr.get_type().get_element_type() != value.get_type().into() {
@@ -2137,14 +1636,7 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicRMW(
-                self.builder,
-                op.into(),
-                ptr.as_value_ref(),
-                value.as_value_ref(),
-                ordering.into(),
-                false as i32,
-            )
+            LLVMBuildAtomicRMW(self.builder, op.into(), ptr.as_value_ref(), value.as_value_ref(), ordering.into(), false as i32)
         };
 
         Ok(IntValue::new(val))
@@ -2207,15 +1699,7 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicCmpXchg(
-                self.builder,
-                ptr.as_value_ref(),
-                cmp.as_value_ref(),
-                new.as_value_ref(),
-                success.into(),
-                failure.into(),
-                false as i32,
-            )
+            LLVMBuildAtomicCmpXchg(self.builder, ptr.as_value_ref(), cmp.as_value_ref(), new.as_value_ref(), success.into(), failure.into(), false as i32)
         };
 
         Ok(StructValue::new(val).into())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,20 +1,48 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
+use llvm_sys::core::{
+    LLVMAddCase, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
+    LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca,
+    LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall,
+    LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
+    LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
+    LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
+    LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP,
+    LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP,
+    LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
+    LLVMBuildIntToPtr, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr, LLVMBuildLoad,
+    LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul, LLVMBuildNSWNeg,
+    LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul, LLVMBuildNUWNeg, LLVMBuildNUWSub,
+    LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildPtrDiff,
+    LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
+    LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl,
+    LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch,
+    LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
+    LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMBuildZExtOrBitCast,
+    LLVMClearInsertionPosition, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock,
+    LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName,
+    LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
+};
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
-use llvm_sys::{LLVMTypeKind};
+use llvm_sys::LLVMTypeKind;
 
-use crate::{AtomicOrdering, AtomicRMWBinOp, IntPredicate, FloatPredicate};
 use crate::basic_block::BasicBlock;
-use crate::values::{AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, PointerMathValue, InstructionOpcode, CallSiteValue};
+use crate::types::{
+    AsTypeRef, BasicType, FloatMathType, IntMathType, PointerMathType, PointerType,
+};
 #[llvm_versions(3.9..=latest)]
 use crate::values::StructValue;
-use crate::types::{AsTypeRef, BasicType, IntMathType, FloatMathType, PointerType, PointerMathType};
+use crate::values::{
+    AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, CallSiteValue,
+    FloatMathValue, FunctionValue, GlobalValue, InstructionOpcode, InstructionValue, IntMathValue,
+    IntValue, PhiValue, PointerMathValue, PointerValue, VectorValue,
+};
+use crate::{AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -61,7 +89,10 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     pub fn build_return(&self, value: Option<&dyn BasicValue<'ctx>>) -> InstructionValue<'ctx> {
         let value = unsafe {
-            value.map_or_else(|| LLVMBuildRetVoid(self.builder), |value| LLVMBuildRet(self.builder, value.as_value_ref()))
+            value.map_or_else(
+                || LLVMBuildRetVoid(self.builder),
+                |value| LLVMBuildRet(self.builder, value.as_value_ref()),
+            )
         };
 
         InstructionValue::new(value)
@@ -90,13 +121,13 @@ impl<'ctx> Builder<'ctx> {
     /// builder.position_at_end(entry);
     /// builder.build_aggregate_return(&[i32_three.into(), i32_seven.into()]);
     /// ```
-    pub fn build_aggregate_return(&self, values: &[BasicValueEnum<'ctx>]) -> InstructionValue<'ctx> {
-        let mut args: Vec<LLVMValueRef> = values.iter()
-                                                .map(|val| val.as_value_ref())
-                                                .collect();
-        let value = unsafe {
-            LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32)
-        };
+    pub fn build_aggregate_return(
+        &self,
+        values: &[BasicValueEnum<'ctx>],
+    ) -> InstructionValue<'ctx> {
+        let mut args: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
+        let value =
+            unsafe { LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32) };
 
         InstructionValue::new(value)
     }
@@ -129,7 +160,12 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&ret_val));
     /// ```
-    pub fn build_call<F>(&self, function: F, args: &[BasicValueEnum<'ctx>], name: &str) -> CallSiteValue<'ctx>
+    pub fn build_call<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> CallSiteValue<'ctx>
     where
         F: Into<FunctionOrPointerValue<'ctx>>,
     {
@@ -145,26 +181,35 @@ impl<'ctx> Builder<'ctx> {
                 };
 
                 // REVIEW: We should probably turn this into a Result?
-                assert!(is_a_fn_ptr, "build_call called with a pointer which is not a function pointer");
+                assert!(
+                    is_a_fn_ptr,
+                    "build_call called with a pointer which is not a function pointer"
+                );
 
                 value_ref
-            },
+            }
         };
 
         // LLVM gets upset when void return calls are named because they don't return anything
         let name = unsafe {
-            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(fn_val_ref)))) {
+            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
+                fn_val_ref,
+            )))) {
                 LLVMTypeKind::LLVMVoidTypeKind => "",
                 _ => name,
             }
         };
 
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let mut args: Vec<LLVMValueRef> = args.iter()
-                                              .map(|val| val.as_value_ref())
-                                              .collect();
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
         let value = unsafe {
-            LLVMBuildCall(self.builder, fn_val_ref, args.as_mut_ptr(), args.len() as u32, c_string.as_ptr())
+            LLVMBuildCall(
+                self.builder,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                c_string.as_ptr(),
+            )
         };
 
         CallSiteValue::new(value)
@@ -172,13 +217,25 @@ impl<'ctx> Builder<'ctx> {
 
     // REVIEW: Doesn't GEP work on array too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
+    pub unsafe fn build_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
-        let value = LLVMBuildGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
+        let value = LLVMBuildGEP(
+            self.builder,
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
 
         PointerValue::new(value)
     }
@@ -186,13 +243,25 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Doesn't GEP work on array too?
     // REVIEW: This could be merge in with build_gep via a in_bounds: bool param
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_in_bounds_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
+    pub unsafe fn build_in_bounds_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
-        let value = LLVMBuildInBoundsGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
+        let value = LLVMBuildInBoundsGEP(
+            self.builder,
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
 
         PointerValue::new(value)
     }
@@ -201,7 +270,12 @@ impl<'ctx> Builder<'ctx> {
     // I think it's the latter. This might not be as unsafe as regular GEP. Should check to see if it lets us
     // go OOB. Maybe we could use the PointerValue<StructValue>'s struct info to do bounds checking...
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_struct_gep(&self, ptr: PointerValue<'ctx>, index: u32, name: &str) -> PointerValue<'ctx> {
+    pub unsafe fn build_struct_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        index: u32,
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = LLVMBuildStructGEP(self.builder, ptr.as_value_ref(), index, c_string.as_ptr());
@@ -234,11 +308,21 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_ptr_diff(i32_ptr_param1, i32_ptr_param2, "diff");
     /// builder.build_return(None);
     /// ```
-    pub fn build_ptr_diff(&self, lhs_ptr: PointerValue<'ctx>, rhs_ptr: PointerValue<'ctx>, name: &str) -> IntValue<'ctx> {
+    pub fn build_ptr_diff(
+        &self,
+        lhs_ptr: PointerValue<'ctx>,
+        rhs_ptr: PointerValue<'ctx>,
+        name: &str,
+    ) -> IntValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPtrDiff(self.builder, lhs_ptr.as_value_ref(), rhs_ptr.as_value_ref(), c_string.as_ptr())
+            LLVMBuildPtrDiff(
+                self.builder,
+                lhs_ptr.as_value_ref(),
+                rhs_ptr.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         IntValue::new(value)
@@ -252,9 +336,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_phi<T: BasicType<'ctx>>(&self, type_: T, name: &str) -> PhiValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr()) };
 
         PhiValue::new(value)
     }
@@ -284,10 +366,13 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_store(i32_ptr_param, i32_seven);
     /// builder.build_return(None);
     /// ```
-    pub fn build_store<V: BasicValue<'ctx>>(&self, ptr: PointerValue<'ctx>, value: V) -> InstructionValue<'ctx> {
-        let value = unsafe {
-            LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref())
-        };
+    pub fn build_store<V: BasicValue<'ctx>>(
+        &self,
+        ptr: PointerValue<'ctx>,
+        value: V,
+    ) -> InstructionValue<'ctx> {
+        let value =
+            unsafe { LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref()) };
 
         InstructionValue::new(value)
     }
@@ -320,9 +405,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         BasicValueEnum::new(value)
     }
@@ -331,19 +414,27 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_alloca<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
 
         PointerValue::new(value)
     }
 
     // TODOC: Stack allocation
-    pub fn build_array_alloca<T: BasicType<'ctx>>(&self, ty: T, size: IntValue<'ctx>, name: &str) -> PointerValue<'ctx> {
+    pub fn build_array_alloca<T: BasicType<'ctx>>(
+        &self,
+        ty: T,
+        size: IntValue<'ctx>,
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildArrayAlloca(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
+            LLVMBuildArrayAlloca(
+                self.builder,
+                ty.as_type_ref(),
+                size.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         PointerValue::new(value)
@@ -410,7 +501,11 @@ impl<'ctx> Builder<'ctx> {
     }
 
     // TODOC: Heap allocation
-    pub fn build_malloc<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> Result<PointerValue<'ctx>, &'static str> {
+    pub fn build_malloc<T: BasicType<'ctx>>(
+        &self,
+        ty: T,
+        name: &str,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidMalloc segfaults if ty is unsized
         if !ty.is_sized() {
             return Err("Cannot build malloc call for an unsized type");
@@ -418,9 +513,7 @@ impl<'ctx> Builder<'ctx> {
 
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
 
         Ok(PointerValue::new(value))
     }
@@ -430,7 +523,7 @@ impl<'ctx> Builder<'ctx> {
         &self,
         ty: T,
         size: IntValue<'ctx>,
-        name: &str
+        name: &str,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidArrayMalloc segfaults if ty is unsized
         if !ty.is_sized() {
@@ -440,7 +533,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildArrayMalloc(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
+            LLVMBuildArrayMalloc(
+                self.builder,
+                ty.as_type_ref(),
+                size.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         Ok(PointerValue::new(value))
@@ -448,9 +546,7 @@ impl<'ctx> Builder<'ctx> {
 
     // SubType: <P>(&self, ptr: PointerValue<P>) -> InstructionValue {
     pub fn build_free(&self, ptr: PointerValue<'ctx>) -> InstructionValue<'ctx> {
-        let val = unsafe {
-            LLVMBuildFree(self.builder, ptr.as_value_ref())
-        };
+        let val = unsafe { LLVMBuildFree(self.builder, ptr.as_value_ref()) };
 
         InstructionValue::new(val)
     }
@@ -458,12 +554,17 @@ impl<'ctx> Builder<'ctx> {
     pub fn insert_instruction(&self, instruction: &InstructionValue<'ctx>, name: Option<&str>) {
         match name {
             Some(name) => {
-                let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+                let c_string =
+                    CString::new(name).expect("Conversion to CString failed unexpectedly");
 
                 unsafe {
-                    LLVMInsertIntoBuilderWithName(self.builder, instruction.as_value_ref(), c_string.as_ptr())
+                    LLVMInsertIntoBuilderWithName(
+                        self.builder,
+                        instruction.as_value_ref(),
+                        c_string.as_ptr(),
+                    )
                 }
-            },
+            }
             None => unsafe {
                 LLVMInsertIntoBuilder(self.builder, instruction.as_value_ref());
             },
@@ -471,9 +572,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn get_insert_block(&self) -> Option<BasicBlock<'ctx>> {
-        let bb = unsafe {
-            LLVMGetInsertBlock(self.builder)
-        };
+        let bb = unsafe { LLVMGetInsertBlock(self.builder) };
 
         BasicBlock::new(bb)
     }
@@ -485,7 +584,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildUDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildUDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -497,7 +601,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -505,11 +614,21 @@ impl<'ctx> Builder<'ctx> {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, name: &str) -> T {
+    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(
+        &self,
+        lhs: T,
+        rhs: T,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildExactSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildExactSDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -521,12 +640,16 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildURem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildURem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
-
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
@@ -534,17 +657,32 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSRem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSExt(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -560,7 +698,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAddrSpaceCast(self.builder, ptr_val.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildAddrSpaceCast(
+                self.builder,
+                ptr_val.as_value_ref(),
+                ptr_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         PointerValue::new(value)
@@ -601,57 +744,112 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildBitCast(self.builder, val.as_value_ref(), ty.as_type_ref(), c_string.as_ptr())
+            LLVMBuildBitCast(
+                self.builder,
+                val.as_value_ref(),
+                ty.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         BasicValueEnum::new(value)
     }
 
-    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSExtOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-       let value = unsafe {
-            LLVMBuildZExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildZExt(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-       let value = unsafe {
-            LLVMBuildZExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildZExtOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_truncate<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-       let value = unsafe {
-            LLVMBuildTrunc(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildTrunc(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-       let value = unsafe {
-            LLVMBuildTruncOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildTruncOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -661,7 +859,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFRem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -677,7 +880,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPToUI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPToUI(
+                self.builder,
+                float.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -692,7 +900,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPToSI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPToSI(
+                self.builder,
+                float.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -708,7 +921,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildUIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildUIToFP(
+                self.builder,
+                int.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
@@ -723,48 +941,93 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSIToFP(
+                self.builder,
+                int.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPTrunc(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPTrunc(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_float_ext<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_ext<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPExt(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPExt(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_float_cast<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_cast<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFPCast(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPCast(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
     // SubType: <L, R>(&self, lhs: &IntValue<L>, rhs: &IntType<R>, name: &str) -> IntValue<R> {
-    pub fn build_int_cast<T: IntMathValue<'ctx>>(&self, int: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildIntCast(self.builder, int.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildIntCast(
+                self.builder,
+                int.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -774,7 +1037,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -785,7 +1053,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -797,7 +1070,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -809,7 +1087,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -820,7 +1103,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -831,7 +1119,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildXor(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildXor(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -842,7 +1135,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildAnd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildAnd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -853,7 +1151,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildOr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildOr(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -906,7 +1209,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildShl(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildShl(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -976,14 +1284,30 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_right_shift<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, sign_extend: bool, name: &str) -> T {
+    pub fn build_right_shift<T: IntMathValue<'ctx>>(
+        &self,
+        lhs: T,
+        rhs: T,
+        sign_extend: bool,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             if sign_extend {
-                LLVMBuildAShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+                LLVMBuildAShr(
+                    self.builder,
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    c_string.as_ptr(),
+                )
             } else {
-                LLVMBuildLShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+                LLVMBuildLShr(
+                    self.builder,
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    c_string.as_ptr(),
+                )
             }
         };
 
@@ -995,7 +1319,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1006,7 +1335,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1018,7 +1352,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1029,7 +1368,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1040,7 +1384,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1052,7 +1401,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNSWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1064,7 +1418,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildNUWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1075,7 +1434,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1091,18 +1455,34 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildCast(self.builder, op.into(), from_value.as_value_ref(), to_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildCast(
+                self.builder,
+                op.into(),
+                from_value.as_value_ref(),
+                to_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         BasicValueEnum::new(value)
     }
 
     // SubType: <F, T>(&self, from: &PointerValue<F>, to: &PointerType<T>, name: &str) -> PointerValue<T> {
-    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(&self, from: T, to: T::BaseType, name: &str) -> T {
+    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(
+        &self,
+        from: T,
+        to: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPointerCast(self.builder, from.as_value_ref(), to.as_type_ref(), c_string.as_ptr())
+            LLVMBuildPointerCast(
+                self.builder,
+                from.as_value_ref(),
+                to.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1112,11 +1492,23 @@ impl<'ctx> Builder<'ctx> {
     // Note: we need a way to get an appropriate return type, since this method's return value
     // is always a bool (or vector of bools), not necessarily the same as the input value
     // See https://github.com/TheDan64/inkwell/pull/47#discussion_r197599297
-    pub fn build_int_compare<T: IntMathValue<'ctx>>(&self, op: IntPredicate, lhs: T, rhs: T, name: &str) -> T {
+    pub fn build_int_compare<T: IntMathValue<'ctx>>(
+        &self,
+        op: IntPredicate,
+        lhs: T,
+        rhs: T,
+        name: &str,
+    ) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildICmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildICmp(
+                self.builder,
+                op.into(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1134,16 +1526,23 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildFCmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFCmp(
+                self.builder,
+                op.into(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_unconditional_branch(&self, destination_block: BasicBlock<'ctx>) -> InstructionValue<'ctx> {
-        let value = unsafe {
-            LLVMBuildBr(self.builder, destination_block.basic_block)
-        };
+    pub fn build_unconditional_branch(
+        &self,
+        destination_block: BasicBlock<'ctx>,
+    ) -> InstructionValue<'ctx> {
+        let value = unsafe { LLVMBuildBr(self.builder, destination_block.basic_block) };
 
         InstructionValue::new(value)
     }
@@ -1155,7 +1554,12 @@ impl<'ctx> Builder<'ctx> {
         else_block: BasicBlock<'ctx>,
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildCondBr(self.builder, comparison.as_value_ref(), then_block.basic_block, else_block.basic_block)
+            LLVMBuildCondBr(
+                self.builder,
+                comparison.as_value_ref(),
+                then_block.basic_block,
+                else_block.basic_block,
+            )
         };
 
         InstructionValue::new(value)
@@ -1167,13 +1571,15 @@ impl<'ctx> Builder<'ctx> {
         destinations: &[BasicBlock<'ctx>],
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildIndirectBr(self.builder, address.as_value_ref(), destinations.len() as u32)
+            LLVMBuildIndirectBr(
+                self.builder,
+                address.as_value_ref(),
+                destinations.len() as u32,
+            )
         };
 
         for destination in destinations {
-            unsafe {
-                LLVMAddDestination(value, destination.basic_block)
-            }
+            unsafe { LLVMAddDestination(value, destination.basic_block) }
         }
 
         InstructionValue::new(value)
@@ -1183,9 +1589,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1195,9 +1599,8 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nsw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value =
+            unsafe { LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1206,9 +1609,8 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nuw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value =
+            unsafe { LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1217,9 +1619,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_float_neg<T: FloatMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1228,9 +1628,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_not<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let value = unsafe {
-            LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1239,14 +1637,16 @@ impl<'ctx> Builder<'ctx> {
     // It'd be great if we could get the BB from the instruction behind the scenes
     pub fn position_at(&self, basic_block: BasicBlock<'ctx>, instruction: &InstructionValue<'ctx>) {
         unsafe {
-            LLVMPositionBuilder(self.builder, basic_block.basic_block, instruction.as_value_ref())
+            LLVMPositionBuilder(
+                self.builder,
+                basic_block.basic_block,
+                instruction.as_value_ref(),
+            )
         }
     }
 
     pub fn position_before(&self, instruction: &InstructionValue<'ctx>) {
-        unsafe {
-            LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref())
-        }
+        unsafe { LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref()) }
     }
 
     pub fn position_at_end(&self, basic_block: BasicBlock<'ctx>) {
@@ -1350,7 +1750,13 @@ impl<'ctx> Builder<'ctx> {
     /// assert!(builder.build_insert_value(array, const_int3, 2, "insert").is_some());
     /// assert!(builder.build_insert_value(array, const_int3, 3, "insert").is_none());
     /// ```
-    pub fn build_insert_value<AV, BV>(&self, agg: AV, value: BV, index: u32, name: &str) -> Option<AggregateValueEnum<'ctx>>
+    pub fn build_insert_value<AV, BV>(
+        &self,
+        agg: AV,
+        value: BV,
+        index: u32,
+        name: &str,
+    ) -> Option<AggregateValueEnum<'ctx>>
     where
         AV: AggregateValue<'ctx>,
         BV: BasicValue<'ctx>,
@@ -1367,7 +1773,13 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildInsertValue(self.builder, agg.as_value_ref(), value.as_value_ref(), index, c_string.as_ptr())
+            LLVMBuildInsertValue(
+                self.builder,
+                agg.as_value_ref(),
+                value.as_value_ref(),
+                index,
+                c_string.as_ptr(),
+            )
         };
 
         Some(AggregateValueEnum::new(value))
@@ -1397,11 +1809,21 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&extracted));
     /// ```
-    pub fn build_extract_element(&self, vector: VectorValue<'ctx>, index: IntValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_extract_element(
+        &self,
+        vector: VectorValue<'ctx>,
+        index: IntValue<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildExtractElement(self.builder, vector.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
+            LLVMBuildExtractElement(
+                self.builder,
+                vector.as_value_ref(),
+                index.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         BasicValueEnum::new(value)
@@ -1442,60 +1864,83 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildInsertElement(self.builder, vector.as_value_ref(), element.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
+            LLVMBuildInsertElement(
+                self.builder,
+                vector.as_value_ref(),
+                element.as_value_ref(),
+                index.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         VectorValue::new(value)
     }
 
     pub fn build_unreachable(&self) -> InstructionValue<'ctx> {
-        let val = unsafe {
-            LLVMBuildUnreachable(self.builder)
-        };
+        let val = unsafe { LLVMBuildUnreachable(self.builder) };
 
         InstructionValue::new(val)
     }
 
     // REVIEW: Not sure if this should return InstructionValue or an actual value
     // TODO: Better name for num?
-    pub fn build_fence(&self, atomic_ordering: AtomicOrdering, num: i32, name: &str) -> InstructionValue<'ctx> {
+    pub fn build_fence(
+        &self,
+        atomic_ordering: AtomicOrdering,
+        num: i32,
+        name: &str,
+    ) -> InstructionValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val = unsafe {
-            LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr())
-        };
+        let val =
+            unsafe { LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr()) };
 
         InstructionValue::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_null<T: PointerMathValue<'ctx>>(
+        &self,
+        ptr: T,
+        name: &str,
+    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val = unsafe {
-            LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let val = unsafe { LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(
+        &self,
+        ptr: T,
+        name: &str,
+    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
-        let val = unsafe {
-            LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let val =
+            unsafe { LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <I, P>(&self, int: &IntValue<I>, ptr_type: &PointerType<P>, name) -> PointerValue<P> {
-    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(&self, int: T, ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
+    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(
+        &self,
+        int: T,
+        ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType,
+        name: &str,
+    ) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildIntToPtr(self.builder, int.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildIntToPtr(
+                self.builder,
+                int.as_value_ref(),
+                ptr_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType::new(value)
@@ -1511,40 +1956,63 @@ impl<'ctx> Builder<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildPtrToInt(self.builder, ptr.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildPtrToInt(
+                self.builder,
+                ptr.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn clear_insertion_position(&self) {
-        unsafe {
-            LLVMClearInsertionPosition(self.builder)
-        }
+        unsafe { LLVMClearInsertionPosition(self.builder) }
     }
 
     // REVIEW: Returning InstructionValue is the safe move here; but if the value means something
     // (IE the result of the switch) it should probably return BasicValueEnum?
     // SubTypes: I think value and case values must be the same subtype (maybe). Case value might need to be constants
-    pub fn build_switch(&self, value: IntValue<'ctx>, else_block: BasicBlock<'ctx>, cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)]) -> InstructionValue<'ctx> {
+    pub fn build_switch(
+        &self,
+        value: IntValue<'ctx>,
+        else_block: BasicBlock<'ctx>,
+        cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)],
+    ) -> InstructionValue<'ctx> {
         let switch_value = unsafe {
-            LLVMBuildSwitch(self.builder, value.as_value_ref(), else_block.basic_block, cases.len() as u32)
+            LLVMBuildSwitch(
+                self.builder,
+                value.as_value_ref(),
+                else_block.basic_block,
+                cases.len() as u32,
+            )
         };
 
         for &(value, basic_block) in cases {
-            unsafe {
-                LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block)
-            }
+            unsafe { LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block) }
         }
 
         InstructionValue::new(switch_value)
     }
 
     // SubTypes: condition can only be IntValue<bool> or VectorValue<IntValue<Bool>>
-    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(&self, condition: IMV, then: BV, else_: BV, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(
+        &self,
+        condition: IMV,
+        then: BV,
+        else_: BV,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildSelect(self.builder, condition.as_value_ref(), then.as_value_ref(), else_.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSelect(
+                self.builder,
+                condition.as_value_ref(),
+                then.as_value_ref(),
+                else_.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         BasicValueEnum::new(value)
@@ -1552,9 +2020,14 @@ impl<'ctx> Builder<'ctx> {
 
     // The unsafety of this function should be fixable with subtypes. See GH #32
     pub unsafe fn build_global_string(&self, value: &str, name: &str) -> GlobalValue<'ctx> {
-        let c_string_value = CString::new(value).expect("Conversion to CString failed unexpectedly");
+        let c_string_value =
+            CString::new(value).expect("Conversion to CString failed unexpectedly");
         let c_string_name = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let value = LLVMBuildGlobalString(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr());
+        let value = LLVMBuildGlobalString(
+            self.builder,
+            c_string_value.as_ptr(),
+            c_string_name.as_ptr(),
+        );
 
         GlobalValue::new(value)
     }
@@ -1562,20 +2035,37 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Does this similar fn have the same issue build_global_string does? If so, mark as unsafe
     // and fix with subtypes.
     pub fn build_global_string_ptr(&self, value: &str, name: &str) -> GlobalValue<'ctx> {
-        let c_string_value = CString::new(value).expect("Conversion to CString failed unexpectedly");
+        let c_string_value =
+            CString::new(value).expect("Conversion to CString failed unexpectedly");
         let c_string_name = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildGlobalStringPtr(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr())
+            LLVMBuildGlobalStringPtr(
+                self.builder,
+                c_string_value.as_ptr(),
+                c_string_name.as_ptr(),
+            )
         };
 
         GlobalValue::new(value)
     }
 
     // REVIEW: Do we need to constrain types here? subtypes?
-    pub fn build_shuffle_vector(&self, left: VectorValue<'ctx>, right: VectorValue<'ctx>, mask: VectorValue<'ctx>, name: &str) -> VectorValue<'ctx> {
+    pub fn build_shuffle_vector(
+        &self,
+        left: VectorValue<'ctx>,
+        right: VectorValue<'ctx>,
+        mask: VectorValue<'ctx>,
+        name: &str,
+    ) -> VectorValue<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
         let value = unsafe {
-            LLVMBuildShuffleVector(self.builder, left.as_value_ref(), right.as_value_ref(), mask.as_value_ref(), c_string.as_ptr())
+            LLVMBuildShuffleVector(
+                self.builder,
+                left.as_value_ref(),
+                right.as_value_ref(),
+                mask.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         VectorValue::new(value)
@@ -1584,11 +2074,21 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Is return type correct?
     // SubTypes: I think this should be type: BT -> BT::Value
     // https://llvm.org/docs/LangRef.html#i-va-arg
-    pub fn build_va_arg<BT: BasicType<'ctx>>(&self, list: PointerValue<'ctx>, type_: BT, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_va_arg<BT: BasicType<'ctx>>(
+        &self,
+        list: PointerValue<'ctx>,
+        type_: BT,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildVAArg(self.builder, list.as_value_ref(), type_.as_type_ref(), c_string.as_ptr())
+            LLVMBuildVAArg(
+                self.builder,
+                list.as_value_ref(),
+                type_.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         BasicValueEnum::new(value)
@@ -1627,8 +2127,9 @@ impl<'ctx> Builder<'ctx> {
         // TODO: add support for fadd, fsub and xchg on floating point types in LLVM 9+.
 
         // "The type of ‘<value>’ must be an integer type whose bit width is a power of two greater than or equal to eight and less than or equal to a target-specific size limit. The type of the ‘<pointer>’ operand must be a pointer to that type." -- https://releases.llvm.org/3.6.2/docs/LangRef.html#atomicrmw-instruction
-        if value.get_type().get_bit_width() < 8 ||
-           !value.get_type().get_bit_width().is_power_of_two() {
+        if value.get_type().get_bit_width() < 8
+            || !value.get_type().get_bit_width().is_power_of_two()
+        {
             return Err("The bitwidth of value must be a power of 2 and greater than 8.");
         }
         if ptr.get_type().get_element_type() != value.get_type().into() {
@@ -1636,7 +2137,14 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicRMW(self.builder, op.into(), ptr.as_value_ref(), value.as_value_ref(), ordering.into(), false as i32)
+            LLVMBuildAtomicRMW(
+                self.builder,
+                op.into(),
+                ptr.as_value_ref(),
+                value.as_value_ref(),
+                ordering.into(),
+                false as i32,
+            )
         };
 
         Ok(IntValue::new(val))
@@ -1699,7 +2207,15 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicCmpXchg(self.builder, ptr.as_value_ref(), cmp.as_value_ref(), new.as_value_ref(), success.into(), failure.into(), false as i32)
+            LLVMBuildAtomicCmpXchg(
+                self.builder,
+                ptr.as_value_ref(),
+                cmp.as_value_ref(),
+                new.as_value_ref(),
+                success.into(),
+                failure.into(),
+                false as i32,
+            )
         };
 
         Ok(StructValue::new(val).into())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,28 +4,27 @@ use either::{Either, Left, Right};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 use llvm_sys::core::{
-    LLVMAddCase, LLVMAddClause, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd,
-    LLVMBuildAddrSpaceCast, LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd,
-    LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr,
-    LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
+    LLVMAddCase, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
+    LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca,
+    LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall,
+    LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
     LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
     LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
     LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP,
     LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP,
     LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
-    LLVMBuildIntToPtr, LLVMBuildInvoke, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr,
-    LLVMBuildLandingPad, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd,
-    LLVMBuildNSWMul, LLVMBuildNSWNeg, LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul,
-    LLVMBuildNUWNeg, LLVMBuildNUWSub, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi,
-    LLVMBuildPointerCast, LLVMBuildPtrDiff, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
-    LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem,
-    LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP,
-    LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv,
-    LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor,
-    LLVMBuildZExt, LLVMBuildZExtOrBitCast, LLVMClearInsertionPosition, LLVMDisposeBuilder,
-    LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind,
-    LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName, LLVMPositionBuilder,
-    LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
+    LLVMBuildIntToPtr, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr, LLVMBuildLoad,
+    LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul, LLVMBuildNSWNeg,
+    LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul, LLVMBuildNUWNeg, LLVMBuildNUWSub,
+    LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildPtrDiff,
+    LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
+    LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl,
+    LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch,
+    LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
+    LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMBuildZExtOrBitCast,
+    LLVMClearInsertionPosition, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock,
+    LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName,
+    LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMTypeOf,
 };
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
@@ -97,38 +96,6 @@ impl<'ctx> Builder<'ctx> {
         };
 
         InstructionValue::new(value)
-    }
-
-    pub fn build_catch_all_landing_pad(
-        &self,
-        ty: &dyn BasicType<'ctx>,
-        value: &dyn BasicValue<'ctx>,
-        ptr_ty: PointerType<'ctx>,
-        name: &str,
-    ) -> BasicValueEnum<'ctx> {
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let num_clauses = 1 as u32;
-
-        let value = unsafe {
-            LLVMBuildLandingPad(
-                self.builder,
-                ty.as_type_ref(),
-                value.as_value_ref(),
-                num_clauses,
-                c_string.as_ptr(),
-            )
-        };
-
-        // we will add one clause, a null pointer of the specified type
-        // NOTE: the ptr type does not actually matter, but we do need a
-        // pointer type to generate the null pointer
-        let null = ptr_ty.const_zero();
-
-        unsafe {
-            LLVMAddClause(value, null.as_value_ref());
-        };
-
-        BasicValueEnum::new(value)
     }
 
     /// Builds a function return instruction for a return type which is an aggregate type (ie structs and arrays).
@@ -241,65 +208,6 @@ impl<'ctx> Builder<'ctx> {
                 fn_val_ref,
                 args.as_mut_ptr(),
                 args.len() as u32,
-                c_string.as_ptr(),
-            )
-        };
-
-        CallSiteValue::new(value)
-    }
-
-    pub fn build_invoke<F>(
-        &self,
-        function: F,
-        args: &[BasicValueEnum<'ctx>],
-        then_block: BasicBlock<'ctx>,
-        catch_block: BasicBlock<'ctx>,
-        name: &str,
-    ) -> CallSiteValue<'ctx>
-    where
-        F: Into<FunctionOrPointerValue<'ctx>>,
-    {
-        let fn_val_ref = match function.into() {
-            Left(val) => val.as_value_ref(),
-            Right(val) => {
-                // If using a pointer value, we must validate it's a valid function ptr
-                let value_ref = val.as_value_ref();
-                let ty_kind = unsafe { LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(value_ref))) };
-                let is_a_fn_ptr = match ty_kind {
-                    LLVMTypeKind::LLVMFunctionTypeKind => true,
-                    _ => false,
-                };
-
-                // REVIEW: We should probably turn this into a Result?
-                assert!(
-                    is_a_fn_ptr,
-                    "build_call called with a pointer which is not a function pointer"
-                );
-
-                value_ref
-            }
-        };
-
-        // LLVM gets upset when void return calls are named because they don't return anything
-        let name = unsafe {
-            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
-                fn_val_ref,
-            )))) {
-                LLVMTypeKind::LLVMVoidTypeKind => "",
-                _ => name,
-            }
-        };
-
-        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
-        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
-        let value = unsafe {
-            LLVMBuildInvoke(
-                self.builder,
-                fn_val_ref,
-                args.as_mut_ptr(),
-                args.len() as u32,
-                then_block.basic_block,
-                catch_block.basic_block,
                 c_string.as_ptr(),
             )
         };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,13 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::LLVMBuildMemCpy;
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::LLVMBuildMemMove;
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 use llvm_sys::{LLVMTypeKind};
 
@@ -352,6 +356,7 @@ impl<'ctx> Builder<'ctx> {
     /// The final argument should be a pointer-sized integer.
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    #[llvm_versions(8.0..=latest)]
     pub fn build_memcpy<T: IntMathValue<'ctx>>(
         &self,
         dest: PointerValue<'ctx>,
@@ -379,6 +384,7 @@ impl<'ctx> Builder<'ctx> {
     /// The final argument should be a pointer-sized integer.
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    #[llvm_versions(8.0..=latest)]
     pub fn build_memmove<T: IntMathValue<'ctx>>(
         &self,
         dest: PointerValue<'ctx>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,9 +5,7 @@ use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArray
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
-use llvm_sys::core::LLVMBuildMemCpy;
-#[llvm_versions(8.0..=latest)]
-use llvm_sys::core::LLVMBuildMemMove;
+use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 use llvm_sys::{LLVMTypeKind};
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -364,7 +364,7 @@ impl<'ctx> Builder<'ctx> {
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
         size: IntValue<'ctx>,
-    ) -> Result<PointerValue<'ctx>, &'static str> {
+    ) -> PointerValue<'ctx> {
         let value = unsafe {
             LLVMBuildMemCpy(
                 self.builder,
@@ -376,7 +376,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        Ok(PointerValue::new(value))
+        PointerValue::new(value)
     }
 
     /// Build a [memmove](http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) instruction.
@@ -394,7 +394,7 @@ impl<'ctx> Builder<'ctx> {
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
         size: IntValue<'ctx>,
-    ) -> Result<PointerValue<'ctx>, &'static str> {
+    ) -> PointerValue<'ctx> {
         let value = unsafe {
             LLVMBuildMemMove(
                 self.builder,
@@ -406,7 +406,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        Ok(PointerValue::new(value))
+        PointerValue::new(value)
     }
 
     // TODOC: Heap allocation

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -349,6 +349,8 @@ impl<'ctx> Builder<'ctx> {
         PointerValue::new(value)
     }
 
+    /// Build a [memcpy](https://llvm.org/docs/LangRef.html#llvm-memcpy-intrinsic) instruction.
+    ///
     /// Alignment arguments are specified in bytes, and should always be a power of 2.
     ///
     /// The final argument should be a pointer-sized integer.
@@ -377,6 +379,8 @@ impl<'ctx> Builder<'ctx> {
         Ok(PointerValue::new(value))
     }
 
+    /// Build a [memmove](http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) instruction.
+    ///
     /// Alignment arguments are specified in bytes, and should always be a power of 2.
     ///
     /// The final argument should be a pointer-sized integer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,11 +284,10 @@ pub enum AtomicRMWBinOp {
     UMin,
 
     /// Adds to the float-typed value in memory and returns the prior value.
-    // TODO: Fix typo OP -> Op once https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/3 is merged.
     // Although this was added in LLVM 9, it wasn't exposed to the C API
     // until 10.0.
     #[llvm_versions(10.0..=latest)]
-    #[llvm_variant(LLVMAtomicRMWBinOPFAdd)]
+    #[llvm_variant(LLVMAtomicRMWBinOpFAdd)]
     FAdd,
 
     /// Subtract a float-typed value off the value in memory and returns the prior value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0"}
+assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///
@@ -282,6 +282,21 @@ pub enum AtomicRMWBinOp {
     /// Sets memory to the unsigned-lesser of the value provided and the value in memory. Returns the value that was in memory.
     #[llvm_variant(LLVMAtomicRMWBinOpUMin)]
     UMin,
+
+    /// Adds to the float-typed value in memory and returns the prior value.
+    // TODO: Fix typo OP -> Op once https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/3 is merged.
+    // Although this was added in LLVM 9, it wasn't exposed to the C API
+    // until 10.0.
+    #[llvm_versions(10.0..=latest)]
+    #[llvm_variant(LLVMAtomicRMWBinOPFAdd)]
+    FAdd,
+
+    /// Subtract a float-typed value off the value in memory and returns the prior value.
+    // Although this was added in LLVM 9, it wasn't exposed to the C API
+    // until 10.0.
+    #[llvm_versions(10.0..=latest)]
+    #[llvm_variant(LLVMAtomicRMWBinOpFSub)]
+    FSub,
 }
 
 /// Defines the optimization level used to compile a `Module`.

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -5,7 +5,7 @@ use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, BasicTypeEnum, BasicType, PointerType, FunctionType};
+use crate::types::{Type, BasicTypeEnum, PointerType, FunctionType};
 use crate::values::{AsValueRef, ArrayValue, IntValue};
 
 /// An `ArrayType` is the type of contiguous constants or variables.
@@ -37,11 +37,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// let i8_array_type_size = i8_array_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.array_type.size_of())
-        }
-
-        None
+        self.array_type.size_of()
     }
 
     /// Gets the alignment of this `ArrayType`. Value may vary depending on the target architecture.

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::types::{IntType, VoidType, FunctionType, PointerType, VectorType, ArrayType, StructType, FloatType};
 use crate::types::traits::AsTypeRef;
+use crate::values::IntValue;
 
 macro_rules! enum_type_set {
     ($(#[$enum_attrs:meta])* $enum_name:ident: { $($(#[$variant_attrs:meta])* $args:ident,)+ }) => (
@@ -233,6 +234,19 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             true
         } else {
             false
+        }
+    }
+
+    pub fn size_of(&self) -> Option<IntValue<'ctx>> {
+        match self {
+            AnyTypeEnum::ArrayType(t) => t.size_of(),
+            AnyTypeEnum::FloatType(t) => Some(t.size_of()),
+            AnyTypeEnum::IntType(t) => Some(t.size_of()),
+            AnyTypeEnum::PointerType(t) => Some(t.size_of()),
+            AnyTypeEnum::StructType(t) => t.size_of(),
+            AnyTypeEnum::VectorType(t) => t.size_of(),
+            AnyTypeEnum::VoidType(_) => None,
+            AnyTypeEnum::FunctionType(_) => None,
         }
     }
 }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -162,7 +162,7 @@ impl<'ctx> FloatType<'ctx> {
     /// let f32_type_size = f32_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.float_type.size_of()
+        self.float_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `FloatType`. Value may vary depending on the target architecture.

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -261,7 +261,7 @@ impl<'ctx> IntType<'ctx> {
     /// let i8_type_size = i8_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.int_type.size_of()
+        self.int_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `IntType`. Value may vary depending on the target architecture.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -172,16 +172,16 @@ impl<'ctx> Type<'ctx> {
         }
     }
 
-    // REVIEW: Option<IntValue>? If we want to provide it on enums that
-    // contain unsized types
-    fn size_of(&self) -> IntValue<'ctx> {
-        debug_assert!(self.is_sized());
+    fn size_of(&self) -> Option<IntValue<'ctx>> {
+        if !self.is_sized() {
+            return None;
+        }
 
         let int_value = unsafe {
             LLVMSizeOf(self.ty)
         };
 
-        IntValue::new(int_value)
+        Some(IntValue::new(int_value))
     }
 
     fn print_to_string(&self) -> LLVMString {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -39,7 +39,7 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_type_size = f32_ptr_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.ptr_type.size_of()
+        self.ptr_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `PointerType`. Value may vary depending on the target architecture.

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -10,7 +10,7 @@ use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, BasicType, BasicTypeEnum, PointerType, FunctionType, Type};
+use crate::types::{ArrayType, BasicTypeEnum, PointerType, FunctionType, Type};
 use crate::values::{ArrayValue, BasicValueEnum, StructValue, IntValue, AsValueRef};
 
 /// A `StructType` is the type of a heterogeneous container of types.
@@ -117,11 +117,7 @@ impl<'ctx> StructType<'ctx> {
     /// let f32_struct_type_size = f32_struct_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.struct_type.size_of());
-        }
-
-        None
+        self.struct_type.size_of()
     }
 
     /// Gets the alignment of this `StructType`. Value may vary depending on the target architecture.

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -75,6 +75,23 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
         Type::new(self.as_type_ref()).is_sized()
     }
 
+    /// Gets the size of this `BasicType`. Value may vary depending on the target architecture.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::types::BasicType;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_basic_type = f32_type.as_basic_type_enum();
+    /// let f32_type_size = f32_basic_type.size_of();
+    /// ```
+    fn size_of(&self) -> Option<IntValue<'ctx>> {
+        Type::new(self.as_type_ref()).size_of()
+    }
+
     /// Create an `ArrayType` with this `BasicType` as its elements.
     ///
     /// Example:

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -4,7 +4,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
-use crate::types::{ArrayType, BasicTypeEnum, BasicType, Type, traits::AsTypeRef, FunctionType, PointerType};
+use crate::types::{ArrayType, BasicTypeEnum, Type, traits::AsTypeRef, FunctionType, PointerType};
 use crate::values::{AsValueRef, ArrayValue, BasicValue, VectorValue, IntValue};
 
 /// A `VectorType` is the type of a multiple value SIMD constant or variable.
@@ -38,11 +38,7 @@ impl<'ctx> VectorType<'ctx> {
     /// let f32_vec_type_size = f32_vec_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.vec_type.size_of())
-        }
-
-        None
+        self.vec_type.size_of()
     }
 
     /// Gets the alignment of this `VectorType`. Value may vary depending on the target architecture.

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -5,9 +5,9 @@ use llvm_sys::prelude::LLVMUseRef;
 use std::marker::PhantomData;
 
 use crate::basic_block::BasicBlock;
-use crate::values::{BasicValueEnum, InstructionValue};
+use crate::values::{AnyValueEnum, BasicValueEnum};
 
-/// A usage of a `BasicValue` in an `InstructionValue`.
+/// A usage of a `BasicValue` in another value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BasicValueUse<'ctx>(LLVMUseRef, PhantomData<&'ctx ()>);
 
@@ -18,7 +18,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         BasicValueUse(use_, PhantomData)
     }
 
-    /// Gets the next use of an `InstructionValue` or `BasicValue` if any.
+    /// Gets the next use of a `BasicValue` if any.
     ///
     /// The following example,
     ///
@@ -83,7 +83,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         Some(Self::new(use_))
     }
 
-    /// Gets the user(an `InstructionValue`) of this use.
+    /// Gets the user (an `AnyValueEnum`) of this use.
     ///
     /// ```no_run
     /// use inkwell::AddressSpace;
@@ -115,15 +115,15 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// assert_eq!(store_operand_use0.get_user(), store_instruction);
     /// assert_eq!(store_operand_use1.get_user(), store_instruction);
     /// ```
-    pub fn get_user(&self) -> InstructionValue<'ctx> {
+    pub fn get_user(&self) -> AnyValueEnum<'ctx> {
         let user = unsafe {
             LLVMGetUser(self.0)
         };
 
-        InstructionValue::new(user)
+        AnyValueEnum::new(user)
     }
 
-    /// Gets the used value(a `BasicValueEnum` or `BasicBlock`) of this use.
+    /// Gets the used value (a `BasicValueEnum` or `BasicBlock`) of this use.
     ///
     /// ```no_run
     /// use inkwell::AddressSpace;

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -18,7 +18,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         BasicValueUse(use_, PhantomData)
     }
 
-    /// Gets the next use of a `BasicValue` if any.
+    /// Gets the next use of an `InstructionValue` or `BasicValue` if any.
     ///
     /// The following example,
     ///

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::{LLVMTypeOf, LLVMGetTypeKind};
+use llvm_sys::core::{LLVMIsAInstruction, LLVMTypeOf, LLVMGetTypeKind};
 use llvm_sys::LLVMTypeKind;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -71,7 +71,12 @@ impl<'ctx> AnyValueEnum<'ctx> {
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
             LLVMTypeKind::LLVMFunctionTypeKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
-            LLVMTypeKind::LLVMVoidTypeKind => panic!("Void values shouldn't exist."),
+            LLVMTypeKind::LLVMVoidTypeKind => {
+                if unsafe { LLVMIsAInstruction(value) }.is_null() {
+                    panic!("Void value isn't an instruction.");
+                }
+                AnyValueEnum::InstructionValue(InstructionValue::new(value))
+            },
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata values are not supported as AnyValue's."),
             _ => panic!("The given type is not supported.")
         }
@@ -157,7 +162,77 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
-    // TODO: into_x_value methods
+    pub fn into_array_value(self) -> ArrayValue<'ctx> {
+        if let AnyValueEnum::ArrayValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_int_value(self) -> IntValue<'ctx> {
+        if let AnyValueEnum::IntValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_float_value(self) -> FloatValue<'ctx> {
+        if let AnyValueEnum::FloatValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_phi_value(self) -> PhiValue<'ctx> {
+        if let AnyValueEnum::PhiValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_function_value(self) -> FunctionValue<'ctx> {
+        if let AnyValueEnum::FunctionValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_pointer_value(self) -> PointerValue<'ctx> {
+        if let AnyValueEnum::PointerValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_struct_value(self) -> StructValue<'ctx> {
+        if let AnyValueEnum::StructValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_vector_value(self) -> VectorValue<'ctx> {
+        if let AnyValueEnum::VectorValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_instruction_value(self) -> InstructionValue<'ctx> {
+        if let AnyValueEnum::InstructionValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
 }
 
 impl<'ctx> BasicValueEnum<'ctx> {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -183,6 +183,7 @@ impl<'ctx> InstructionValue<'ctx> {
     }
 
     pub fn is_tail_call(&self) -> bool {
+        // LLVMIsTailCall has UB if the value is not an llvm::CallInst*.
         if self.get_opcode() == InstructionOpcode::Call {
             unsafe {
                 LLVMIsTailCall(self.as_value_ref()) == 1

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -182,11 +182,13 @@ impl<'ctx> InstructionValue<'ctx> {
         BasicBlock::new(value)
     }
 
-    // REVIEW: See if necessary to check opcode == Call first.
-    // Does it always return false otherwise?
     pub fn is_tail_call(&self) -> bool {
-        unsafe {
-            LLVMIsTailCall(self.as_value_ref()) == 1
+        if self.get_opcode() == InstructionOpcode::Call {
+            unsafe {
+                LLVMIsTailCall(self.as_value_ref()) == 1
+            }
+        } else {
+            false
         }
     }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -29,6 +29,8 @@ pub enum InstructionOpcode {
     BitCast,
     Br,
     Call,
+    #[llvm_versions(9.0..=latest)]
+    CallBr,
     #[llvm_versions(3.8..=latest)]
     CatchPad,
     #[llvm_versions(3.8..=latest)]
@@ -52,6 +54,8 @@ pub enum InstructionOpcode {
     FPToSI,
     FPToUI,
     FPTrunc,
+    #[llvm_versions(10.0..=latest)]
+    Freeze,
     FRem,
     FSub,
     GetElementPtr,

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -34,6 +34,10 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 #[cfg(feature = "llvm8-0")]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 26;
+#[cfg(feature = "llvm9-0")]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 28;
+#[cfg(feature = "llvm10-0")]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 30;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue<'ctx> {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -173,8 +173,11 @@ impl<'ctx> Value<'ctx> {
     // REVIEW: I think this is memory safe, though it may result in an IR error
     // if used incorrectly, which is OK.
     fn replace_all_uses_with(&self, other: LLVMValueRef) {
-        unsafe {
-            LLVMReplaceAllUsesWith(self.value, other)
+        // LLVM may infinite-loop when they aren't distinct, which is UB in C++.
+        if self.value != other {
+            unsafe {
+                LLVMReplaceAllUsesWith(self.value, other)
+            }
         }
     }
 

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -24,13 +24,6 @@ fn test_enum_attribute_kinds() {
     assert_eq!(Attribute::get_named_enum_kind_id("builtin"), 5);
     assert_eq!(Attribute::get_named_enum_kind_id("cold"), 7);
     assert_eq!(Attribute::get_named_enum_kind_id("convergent"), 8);
-    assert_eq!(Attribute::get_named_enum_kind_id("inaccessiblememonly"), 13);
-    assert_eq!(Attribute::get_named_enum_kind_id("inaccessiblemem_or_argmemonly"), 14);
-    assert_eq!(Attribute::get_named_enum_kind_id("inlinehint"), 15);
-    assert_eq!(Attribute::get_named_enum_kind_id("jumptable"), 16);
-    assert_eq!(Attribute::get_named_enum_kind_id("minsize"), 17);
-    assert_eq!(Attribute::get_named_enum_kind_id("naked"), 18);
-    assert_eq!(Attribute::get_named_enum_kind_id("nobuiltin"), 21);
 
     // REVIEW: The LLVM docs suggest these fn attrs exist, but don't turn up:
     // assert_eq!(Attribute::get_named_enum_kind_id("no-jump-tables"), 19);
@@ -49,11 +42,6 @@ fn test_enum_attribute_kinds() {
     assert_eq!(Attribute::get_named_enum_kind_id("byval"), 6);
     assert_eq!(Attribute::get_named_enum_kind_id("dereferenceable"), 9);
     assert_eq!(Attribute::get_named_enum_kind_id("dereferenceable_or_null"), 10);
-    assert_eq!(Attribute::get_named_enum_kind_id("inalloca"), 11);
-    assert_eq!(Attribute::get_named_enum_kind_id("inreg"), 12);
-    assert_eq!(Attribute::get_named_enum_kind_id("nest"), 19);
-    assert_eq!(Attribute::get_named_enum_kind_id("noalias"), 20);
-    assert_eq!(Attribute::get_named_enum_kind_id("nocapture"), 22);
 }
 
 #[test]

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -163,3 +163,22 @@ fn test_no_parent() {
 
     assert!(basic_block.get_parent().is_none());
 }
+
+#[test]
+fn test_rauw() {
+    let context = Context::create();
+    let builder = context.create_builder();
+    let module = context.create_module("my_mod");
+    let void_type = context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+    let fn_val = module.add_function("my_fn", fn_type, None);
+    let entry = context.append_basic_block(fn_val, "entry");
+    let bb1 = context.append_basic_block(fn_val, "bb1");
+    let bb2 = context.append_basic_block(fn_val, "bb2");
+    builder.position_at_end(entry);
+    let branch_inst = builder.build_unconditional_branch(bb1);
+
+    bb1.replace_all_uses_with(&bb2);
+
+    assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);
+}

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -178,6 +178,7 @@ fn test_rauw() {
     builder.position_at_end(entry);
     let branch_inst = builder.build_unconditional_branch(bb1);
 
+    bb1.replace_all_uses_with(&bb1);  // no-op
     bb1.replace_all_uses_with(&bb2);
 
     assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -662,6 +662,14 @@ fn test_alignment_bytes() {
         } else {
             assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memcpy when it should not have.", alignment);
         }
+
+        run_memmove_on(&context, &module, alignment);
+
+        if alignment == 0 || alignment.is_power_of_two() {
+            assert!(module.verify().is_ok(), "alignment of {:?} was neither 0 nor a power of 2, but did not verify for memmov.", alignment);
+        } else {
+            assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memmov when it should not have.", alignment);
+        }
     };
 
     for alignment in 0..32 {
@@ -733,6 +741,67 @@ fn test_memcpy() {
     }
 }
 
+#[llvm_versions(8.0..=latest)]
+fn run_memmove_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::Module<'ctx>, alignment: u32) {
+    let i32_type = context.i32_type();
+    let i64_type = context.i64_type();
+    let array_len = 4;
+    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_value = module.add_function("test_fn", fn_type, None);
+    let builder = context.create_builder();
+    let entry = context.append_basic_block(fn_value, "entry");
+
+    builder.position_at_end(entry);
+
+    let len_value = i64_type.const_int(array_len as u64, false);
+    let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
+
+    // Initialize the array with the values [1, 2, 3, 4]
+    for index in 0..4 {
+        let index_val = i32_type.const_int(index, false);
+        let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+        let int_val = i32_type.const_int(index + 1, false);
+
+        builder.build_store(elem_ptr, int_val);
+    }
+
+    // Memcpy the first half of the array over the second half of the array.
+    let elems_to_copy = 2;
+    let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
+    let size_val = i64_type.const_int(bytes_to_copy as u64, false);
+    let index_val = i32_type.const_int(2, false);
+    let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+
+    builder.build_memmove(dest_ptr, alignment, array_ptr, alignment, size_val);
+
+    builder.build_return(Some(&array_ptr));
+}
+
+#[llvm_versions(8.0..=latest)]
+#[test]
+fn test_memmove() {
+    // 1. Allocate an array with a few elements.
+    // 2. Memmove from the first half of the array to the second half.
+    // 3. Run the code in an execution engine and verify the array's contents.
+    let context = Context::create();
+    let module = context.create_module("av");
+
+    run_memcpy_on(&context, &module, 8);
+
+    // Verify the module
+    if let Err(errors) = module.verify() {
+        panic!("Errors defining module: {:?}", errors);
+    }
+
+    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+
+    unsafe {
+        let func = execution_engine.get_function::<unsafe extern "C" fn() -> *const i32>("test_fn").unwrap();
+        let actual = std::slice::from_raw_parts(func.call(), 4);
+
+        assert_eq!(&[1, 2, 1, 2], actual);
+    }
+}
 
 #[test]
 fn test_bitcast() {

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -648,8 +648,8 @@ fn test_insert_value() {
     assert!(module.verify().is_ok());
 }
 
-#[test]
 #[llvm_versions(8.0..=latest)]
+#[test]
 fn test_alignment_bytes() {
     let verify_alignment = |alignment: u32| {
         let context = Context::create();
@@ -707,8 +707,8 @@ fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::M
     builder.build_return(Some(&array_ptr));
 }
 
-#[test]
 #[llvm_versions(8.0..=latest)]
+#[test]
 fn test_memcpy() {
     // 1. Allocate an array with a few elements.
     // 2. Memcpy from the first half of the array to the second half.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -2,7 +2,6 @@ extern crate inkwell;
 
 use self::inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, OptimizationLevel};
 use self::inkwell::context::Context;
-use self::inkwell::module::Module;
 use self::inkwell::values::BasicValue;
 
 // use std::ffi::CString;
@@ -673,7 +672,7 @@ fn test_alignment_bytes() {
 }
 
 #[llvm_versions(8.0..=latest)]
-fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &Module<'ctx>, alignment: u32) {
+fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::Module<'ctx>, alignment: u32) {
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -649,6 +649,7 @@ fn test_insert_value() {
 }
 
 #[test]
+#[llvm_versions(8.0..=latest)]
 fn test_memcpy() {
     // 1. Allocate an array with a few elements.
     // 2. Memcpy from the first half of the array to the second half.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -686,7 +686,7 @@ fn test_memcpy() {
     let index_val = i32_type.const_int(2, false);
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
 
-    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val).unwrap();
+    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val);
 
     builder.build_return(Some(&array_ptr));
 

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -649,6 +649,29 @@ fn test_insert_value() {
     assert!(module.verify().is_ok());
 }
 
+#[test]
+#[llvm_versions(8.0..=latest)]
+fn test_alignment_bytes() {
+    let verify_alignment = |alignment: u32| {
+        let context = Context::create();
+        let module = context.create_module("av");
+
+        run_memcpy_on(&context, &module, alignment);
+
+        if alignment == 0 || alignment.is_power_of_two() {
+            assert!(module.verify().is_ok(), "alignment of {:?} was neither 0 nor a power of 2, but did not verify for memcpy.", alignment);
+        } else {
+            assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memcpy when it should not have.", alignment);
+        }
+    };
+
+    for alignment in 0..32 {
+        verify_alignment(alignment);
+    }
+
+    verify_alignment(u32::max_value());
+}
+
 #[llvm_versions(8.0..=latest)]
 fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &Module<'ctx>, alignment: u32) {
     let i32_type = context.i32_type();

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -678,7 +678,14 @@ fn test_memcpy() {
     }
 
     // Memcpy the first half of the array over the second half of the array.
-    // TODO run the memcpy here
+    let elems_to_copy = 2;
+    let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
+    let size_val = i64_type.const_int(bytes_to_copy as u64, false);
+    let alignment = 8;
+    let index_val = i32_type.const_int(2, false);
+    let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+
+    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val).unwrap();
 
     builder.build_return(Some(&array_ptr));
 

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -109,8 +109,8 @@ fn test_operands() {
     assert!(store_operand_use1.get_next_use().is_none());
     assert_eq!(store_operand_use1, arg1_second_use);
 
-    assert_eq!(store_operand_use0.get_user(), store_instruction);
-    assert_eq!(store_operand_use1.get_user(), store_instruction);
+    assert_eq!(store_operand_use0.get_user().into_instruction_value(), store_instruction);
+    assert_eq!(store_operand_use1.get_user().into_instruction_value(), store_instruction);
     assert_eq!(store_operand_use0.get_used_value().left().unwrap(), f32_val);
     assert_eq!(store_operand_use1.get_used_value().left().unwrap(), arg1);
 
@@ -185,7 +185,7 @@ fn test_get_next_use() {
     let first_use = f32_val.get_first_use().unwrap();
 
     assert_eq!(first_use.get_user(), add_pi1.as_instruction_value().unwrap());
-    assert_eq!(first_use.get_next_use().map(|x| x.get_user()), add_pi0.as_instruction_value());
+    assert_eq!(first_use.get_next_use().map(|x| x.get_user().into_float_value()), Some(add_pi0));
     assert!(arg1.get_first_use().is_some());
     assert!(module.verify().is_ok());
 }

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -139,9 +139,9 @@ fn test_pass_manager_builder() {
     let module2 = module.clone();
 
     // TODOC: In 3.6, 3.8, & 3.9 it returns false. Seems like a LLVM bug?
-    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
+    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
     assert!(!module_pass_manager.run_on(&module));
-    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
+    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0"))]
     assert!(module_pass_manager.run_on(&module));
 
     let lto_pass_manager = PassManager::create(());

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -139,9 +139,9 @@ fn test_pass_manager_builder() {
     let module2 = module.clone();
 
     // TODOC: In 3.6, 3.8, & 3.9 it returns false. Seems like a LLVM bug?
-    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
+    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
     assert!(!module_pass_manager.run_on(&module));
-    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0"))]
+    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0"))]
     assert!(module_pass_manager.run_on(&module));
 
     let lto_pass_manager = PassManager::create(());

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -371,6 +371,8 @@ fn test_basic_type_enum() {
                    basic_type.ptr_type(addr));
         assert_eq!(basic_type.as_basic_type_enum().array_type(0),
                    basic_type.array_type(0));
+        assert_eq!(basic_type.as_basic_type_enum().size_of(),
+                   basic_type.size_of());
     }
 }
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -323,10 +323,10 @@ fn test_verify_fn() {
 
     let function = module.add_function("fn", fn_type, None);
 
-    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
+    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
     assert!(!function.verify(false));
     // REVIEW: Why does 3.9 -> 8.0 return true here? LLVM bug? Bugfix?
-    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0"))]
+    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0"))]
     assert!(function.verify(false));
 
     let basic_block = context.append_basic_block(function, "entry");
@@ -732,7 +732,7 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     // REVIEW: Segfaults in 4.0 -> 7.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
     assert_eq!(global.get_section(), &*CString::new("").unwrap());
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -323,10 +323,10 @@ fn test_verify_fn() {
 
     let function = module.add_function("fn", fn_type, None);
 
-    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
+    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
     assert!(!function.verify(false));
     // REVIEW: Why does 3.9 -> 8.0 return true here? LLVM bug? Bugfix?
-    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
+    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0"))]
     assert!(function.verify(false));
 
     let basic_block = context.append_basic_block(function, "entry");
@@ -664,9 +664,10 @@ fn test_value_from_string() {
 
     assert_eq!(f64_val.print_to_string().to_string(), "double 0.000000e+00");
 
-    let f64_val = f64_type.const_float_from_string("3.asd");
-
-    assert_eq!(f64_val.print_to_string().to_string(), "double 0x7FF0000000000000");
+    // TODO: We should return a Result that returns Err here.
+    //let f64_val = f64_type.const_float_from_string("3.asd");
+    //
+    //assert_eq!(f64_val.print_to_string().to_string(), "double 0x7FF0000000000000");
 }
 
 #[test]
@@ -731,7 +732,7 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     // REVIEW: Segfaults in 4.0 -> 7.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm10-0")))]
     assert_eq!(global.get_section(), &*CString::new("").unwrap());
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());


### PR DESCRIPTION
Add primitives for Roc exception handling.

Inkwell does not use rustfmt (yet). So the first commit `rustfmt`s the builder file, then makes the additions in a separate commit (if ever we do want to upstream this, we can pick the changes from there).

It turns out we only need two things: a catch-all landing pad, and access to the `invoke` instruction. Fully implementing landing pad would require more API design work.