### PR TITLE
llvm-sys update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ llvm-sys-80 = { package = "llvm-sys", version = "80.3", optional = true }
 llvm-sys-90 = { package = "llvm-sys", version = "90.2", optional = true }
 llvm-sys-100 = { package = "llvm-sys", version = "100.2", optional = true }
 llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
-llvm-sys-120 = { package = "llvm-sys", version = "120.0", optional = true }
+llvm-sys-120 = { package = "llvm-sys", version = "120.2", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
 regex = "1"


### PR DESCRIPTION
The build script for llvm-sys fails on debian bullseye, I'm hoping updating llvm-sys fixes it.

This was the error I encountered:
```
assertion failed: flag.starts_with(\"-l\")', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/llvm-sys-120
```