### PR TITLE
Set llvm-sys-120 dependency to use llvm-sys master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ llvm-sys-80 = { package = "llvm-sys", version = "80.3", optional = true }
 llvm-sys-90 = { package = "llvm-sys", version = "90.2", optional = true }
 llvm-sys-100 = { package = "llvm-sys", version = "100.2", optional = true }
 llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
-llvm-sys-120 = { package = "llvm-sys", version = "120.2", optional = true }
+llvm-sys-120 = { package = "llvm-sys", git = "https://gitlab.com/taricorp/llvm-sys.rs", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
 regex = "1"


### PR DESCRIPTION
The fix for my debian bullseye issue was on the llvm-sys master, but not yet released.
I've asked the maintainer to do another release to make this fix available.
I've updated `Cargo.toml` to use the current master of llvm-sys.
This carries some risk because any commit on master can break llvm-sys.
The maintainer was active yesterday so we can opt to wait for a release, if not we can merge this PR.